### PR TITLE
Add protocol invite and routing model

### DIFF
--- a/crates/satspath-cli/src/commands/mod.rs
+++ b/crates/satspath-cli/src/commands/mod.rs
@@ -34,7 +34,9 @@ pub(crate) fn open_registry() -> Result<Registry> {
 }
 
 use satspath_core::resolver::ChainResolver;
+use satspath_core::resolvers::bip353::Bip353Resolver;
 use satspath_core::resolvers::http::HttpResolver;
+use satspath_core::resolvers::nostr::NostrResolver;
 
 pub(crate) fn get_resolver() -> Result<ChainResolver> {
     let mut chain = ChainResolver::new();
@@ -44,8 +46,11 @@ pub(crate) fn get_resolver() -> Result<ChainResolver> {
         chain = chain.push(reg);
     }
 
+    chain = chain.push(Bip353Resolver::new());
+
     // Add public HTTP resolver fallback
     chain = chain.push(HttpResolver::new());
+    chain = chain.push(NostrResolver);
 
     Ok(chain)
 }

--- a/crates/satspath-cli/src/commands/pay.rs
+++ b/crates/satspath-cli/src/commands/pay.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
 use satspath_core::{
+    create_invite_record,
     crypto::verify_signed_profile,
     pointer::build_qr_payload,
     privacy::{mask_address, mask_identifier, mask_invoice, mask_pubkey},
@@ -9,7 +10,7 @@ use satspath_core::{
         assert_no_private_material, validate_amount_sats, validate_bitcoin_address,
         validate_compressed_pubkey, validate_lightning_address, LARGE_PREVIEW_AMOUNT_SATS,
     },
-    BitcoinNetwork, PaymentMethod, PaymentPointer,
+    BitcoinNetwork, PaymentMethod, PaymentPointer, SatsPathError,
 };
 use satspath_router::{select_route, RouteRequest, SwapDirective};
 
@@ -62,10 +63,26 @@ pub async fn cmd_pay(
 
     println!("Resolving identifier {}...", display_alias);
     let resolver = get_resolver()?;
-    let signed = resolver
-        .resolve_alias(alias)
-        .await
-        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let signed = match resolver.resolve_alias(alias).await {
+        Ok(signed) => signed,
+        Err(SatsPathError::AliasNotFound(_)) => {
+            let invite = create_invite_record(
+                alias,
+                amount_sats,
+                memo.map(str::to_string),
+                "local-sender".into(),
+                7 * 24 * 60 * 60,
+            );
+            println!("No signed profile found.");
+            println!("Created invite: {}", invite.invite_id);
+            println!("Receiver must verify email and publish a signed public payment profile.");
+            println!("No funds moved.");
+            println!("No signing performed.");
+            println!("No private keys touched.");
+            return Ok(());
+        }
+        Err(e) => return Err(anyhow::anyhow!("{}", e)),
+    };
     println!("  Found signed profile.");
 
     println!("Verifying signed profile...");
@@ -94,7 +111,7 @@ pub async fn cmd_pay(
     } else {
         BitcoinNetwork::Mainnet
     };
-    let pointer = payment_method_to_pointer(&quote.selected_method, network)?;
+    let pointer = payment_method_to_pointer(&quote.selected_method)?;
     validate_pointer_for_preview(&pointer, mainnet_preview, network)?;
     let qr_payload =
         build_qr_payload(&pointer, amount_sats).map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -222,10 +239,7 @@ async fn exec_experimental(
     Ok(())
 }
 
-fn payment_method_to_pointer(
-    method: &PaymentMethod,
-    network: BitcoinNetwork,
-) -> Result<PaymentPointer> {
+fn payment_method_to_pointer(method: &PaymentMethod) -> Result<PaymentPointer> {
     match method {
         PaymentMethod::Lightning {
             lnurl,
@@ -241,7 +255,6 @@ fn payment_method_to_pointer(
             } else if let Some(callback_url) = lnurl {
                 Ok(PaymentPointer::LnurlPay {
                     callback_url: callback_url.clone(),
-                    metadata_hash: None,
                     receiver_pubkey: None,
                 })
             } else if let Some(invoice) = bolt12 {
@@ -254,13 +267,11 @@ fn payment_method_to_pointer(
             }
         }
         PaymentMethod::Onchain {
-            address,
-            pubkey_hint,
-            ..
+            address, network, ..
         } => Ok(PaymentPointer::OnchainAddress {
-            network,
+            network: *network,
             address: address.clone(),
-            derivation_hint: pubkey_hint.clone(),
+            claim_policy: None,
         }),
         PaymentMethod::Ark { server, pubkey, .. } => Ok(PaymentPointer::Ark {
             server: server.clone(),

--- a/crates/satspath-cli/src/commands/quote.rs
+++ b/crates/satspath-cli/src/commands/quote.rs
@@ -76,15 +76,29 @@ pub async fn cmd_quote(alias: &str, amount_sats: u64) -> Result<()> {
                 .ok_or_else(|| anyhow::anyhow!("no Lightning Address in method"))?;
 
             print!("  Fetching invoice from {}... ", mask_identifier(ln_addr));
-            let meta = fetch_lnurl_metadata(ln_addr).await?;
-            let invoice = fetch_invoice(&meta, amount_sats, None).await?;
-            println!("received.");
-            println!();
-            println!("  Scan to pay — Lightning ({} sats)", amount_sats);
-            println!("  ─────────────────────────────────────────");
-            print_qr(&invoice.to_uppercase())?;
-            println!("  {}...", mask_invoice(&invoice));
-            println!("  Warning: this is a real invoice QR generated from public metadata.");
+            match fetch_lnurl_metadata(ln_addr).await {
+                Ok(meta) => {
+                    match fetch_invoice(&meta, amount_sats, None).await {
+                        Ok(invoice) => {
+                            println!("received.");
+                            println!();
+                            println!("  Scan to pay — Lightning ({} sats)", amount_sats);
+                            println!("  ─────────────────────────────────────────");
+                            print_qr(&invoice.to_uppercase())?;
+                            println!("  {}...", mask_invoice(&invoice));
+                            println!("  Warning: this is a real invoice QR generated from public metadata.");
+                        }
+                        Err(e) => {
+                            println!("unavailable ({e}).");
+                            println!("  Preview only. No funds moved.");
+                        }
+                    }
+                }
+                Err(e) => {
+                    println!("unavailable ({e}).");
+                    println!("  Preview only. No funds moved.");
+                }
+            }
         }
         PaymentMethod::Onchain { address, .. } => {
             let uri = bitcoin_uri(address, amount_sats);

--- a/crates/satspath-cli/src/commands/register.rs
+++ b/crates/satspath-cli/src/commands/register.rs
@@ -36,9 +36,10 @@ pub fn cmd_register(
 
     let mut methods = vec![PaymentMethod::Lightning {
         label: "Lightning Address".into(),
-        lnurl: None,
         lightning_address: Some(lightning_address.to_string()),
+        lnurl: None,
         bolt12: None,
+        receiver_pubkey: None,
     }];
 
     if let Some(address) = onchain_address {
@@ -46,8 +47,10 @@ pub fn cmd_register(
             .map_err(|e| anyhow::anyhow!("{}", e))?;
         methods.push(PaymentMethod::Onchain {
             label: "Bitcoin mainnet".into(),
+            network: BitcoinNetwork::Mainnet,
             address: address.to_string(),
             pubkey_hint: None,
+            descriptor_hint: None,
         });
     }
 
@@ -58,6 +61,7 @@ pub fn cmd_register(
                 label: "Ark".into(),
                 server: server.to_string(),
                 pubkey: pubkey.to_string(),
+                vtxo_pointer: None,
             });
         }
         (None, None) => {}
@@ -69,6 +73,7 @@ pub fn cmd_register(
         identity_pubkey: pubkey_hex.clone(),
         methods: methods.clone(),
         updated_at: chrono::Utc::now().timestamp(),
+        expires_at: None,
     };
 
     let signed = sign_profile(profile, &kp.secret_key)?;

--- a/crates/satspath-cli/src/commands/show.rs
+++ b/crates/satspath-cli/src/commands/show.rs
@@ -43,6 +43,7 @@ pub async fn cmd_show(alias: &str) -> Result<()> {
                 lightning_address,
                 lnurl,
                 bolt12,
+                receiver_pubkey,
             } => {
                 println!("  - {} [Lightning]", label);
                 if let Some(la) = lightning_address {
@@ -54,26 +55,39 @@ pub async fn cmd_show(alias: &str) -> Result<()> {
                 if let Some(b12) = bolt12 {
                     println!("      BOLT12: {}", mask_invoice(b12));
                 }
+                if let Some(pubkey) = receiver_pubkey {
+                    println!("      Receiver pubkey: {}", mask_pubkey(pubkey));
+                }
             }
             PaymentMethod::Onchain {
                 label,
+                network,
                 address,
                 pubkey_hint,
+                descriptor_hint,
             } => {
                 println!("  - {} [On-chain]", label);
+                println!("      Network: {:?}", network);
                 println!("      Address: {}", mask_address(address));
                 if let Some(hint) = pubkey_hint {
                     println!("      Pubkey hint: {}", mask_pubkey(hint));
+                }
+                if descriptor_hint.is_some() {
+                    println!("      Descriptor hint: present");
                 }
             }
             PaymentMethod::Ark {
                 label,
                 server,
                 pubkey,
+                vtxo_pointer,
             } => {
                 println!("  - {} [Ark]", label);
                 println!("      Server: {}", mask_address(server));
                 println!("      Pubkey: {}", mask_pubkey(pubkey));
+                if vtxo_pointer.is_some() {
+                    println!("      VTXO pointer: present");
+                }
             }
         }
     }

--- a/crates/satspath-core/src/crypto.rs
+++ b/crates/satspath-core/src/crypto.rs
@@ -86,11 +86,13 @@ mod tests {
             identity_pubkey: pubkey_hex.into(),
             methods: vec![PaymentMethod::Lightning {
                 label: "Lightning".into(),
-                lnurl: None,
                 lightning_address: Some("test@example.com".into()),
+                lnurl: None,
                 bolt12: None,
+                receiver_pubkey: None,
             }],
             updated_at: 1_700_000_000,
+            expires_at: None,
         }
     }
 

--- a/crates/satspath-core/src/lib.rs
+++ b/crates/satspath-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod codec;
 pub mod crypto;
 pub mod errors;
 pub mod peer_registry;
+pub mod platform;
 pub mod pointer;
 pub mod privacy;
 pub mod profile;
@@ -15,8 +16,14 @@ pub use peer_registry::{
     canonicalize_identifier, display_hint, hash_identifier, LocalPeerRegistry, MockPeerRegistry,
     PeerPointers, PeerRecord, PeerRegistryBackend,
 };
+pub use platform::{
+    EmailChallenge, EmailVerifier, ProfilePublisher, PublishReceipt, VerifiedIdentifier,
+};
 pub use pointer::{BitcoinNetwork, PaymentPointer};
-pub use profile::{Invite, PaymentMethod, PaymentProfile, PaymentRequest, SignedPaymentProfile};
+pub use profile::{
+    ClaimPolicy, Invite, InviteRecord, InviteStatus, PaymentMethod, PaymentProfile, PaymentRequest,
+    SignedPaymentProfile,
+};
 
 use sha2::{Digest, Sha256};
 
@@ -42,5 +49,47 @@ pub fn create_invite(alias: &str, amount_sats: u64) -> Invite {
         warning: "The receiver must claim this payment by generating their own keys locally. \
                   SatsPath never holds or generates keys on behalf of users."
             .into(),
+    }
+}
+
+pub fn create_invite_record(
+    identifier: &str,
+    amount_sats: u64,
+    memo: Option<String>,
+    sender_fingerprint: String,
+    ttl_seconds: i64,
+) -> InviteRecord {
+    let now = chrono::Utc::now().timestamp();
+    InviteRecord {
+        invite_id: uuid::Uuid::new_v4().to_string(),
+        identifier_hash: privacy::identifier_hash(identifier),
+        display_hint: privacy::mask_identifier(identifier),
+        amount_sats,
+        memo,
+        sender_fingerprint,
+        status: InviteStatus::Created,
+        created_at: now,
+        expires_at: now + ttl_seconds,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_user_invite_record_contains_no_private_material() {
+        let invite = create_invite_record(
+            "someone@gmail.com",
+            1_000,
+            Some("coffee".into()),
+            "sender-fp".into(),
+            600,
+        );
+        assert_eq!(invite.status, InviteStatus::Created);
+        assert_eq!(invite.display_hint, "s***@gmail.com");
+        assert!(!format!("{invite:?}").contains("seed"));
+        assert!(!format!("{invite:?}").contains("xprv"));
+        assert!(invite.expires_at > invite.created_at);
     }
 }

--- a/crates/satspath-core/src/platform.rs
+++ b/crates/satspath-core/src/platform.rs
@@ -1,0 +1,82 @@
+use crate::privacy::{identifier_hash, mask_identifier};
+use crate::{Result, SatsPathError, SignedPaymentProfile};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmailChallenge {
+    pub challenge_id: String,
+    pub identifier_hash: String,
+    pub expires_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedIdentifier {
+    pub identifier_hash: String,
+    pub verified_at: i64,
+}
+
+/// Platform-layer inbox verifier.
+///
+/// Verification proves access to an inbox. It does not prove domain ownership,
+/// transfer custody, or give SatsPath access to wallet keys.
+pub trait EmailVerifier {
+    fn create_challenge(&self, identifier: &str) -> Result<EmailChallenge>;
+    fn verify_challenge(&self, token: &str) -> Result<VerifiedIdentifier>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublishReceipt {
+    pub profile_fingerprint: String,
+    pub published_at: i64,
+    pub location_hint: Option<String>,
+}
+
+pub trait ProfilePublisher {
+    fn publish_profile(&self, profile: &SignedPaymentProfile) -> Result<PublishReceipt>;
+}
+
+pub struct MockEmailVerifier {
+    pub now: i64,
+    pub ttl_seconds: i64,
+}
+
+impl EmailVerifier for MockEmailVerifier {
+    fn create_challenge(&self, identifier: &str) -> Result<EmailChallenge> {
+        Ok(EmailChallenge {
+            challenge_id: format!("mock-{}", mask_identifier(identifier)),
+            identifier_hash: identifier_hash(identifier),
+            expires_at: self.now + self.ttl_seconds,
+        })
+    }
+
+    fn verify_challenge(&self, token: &str) -> Result<VerifiedIdentifier> {
+        if token.is_empty() || token.contains("seed") || token.contains("xprv") {
+            return Err(SatsPathError::PrivateMaterialRejected(
+                "invalid verification token".into(),
+            ));
+        }
+        Ok(VerifiedIdentifier {
+            identifier_hash: identifier_hash(token),
+            verified_at: self.now,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn email_verification_creates_verified_identifier_not_keys() {
+        let verifier = MockEmailVerifier {
+            now: 1_700_000_000,
+            ttl_seconds: 600,
+        };
+        let challenge = verifier.create_challenge("Alice@Gmail.com").unwrap();
+        assert!(!challenge.identifier_hash.contains("Alice"));
+        assert!(challenge.expires_at > verifier.now);
+
+        let verified = verifier.verify_challenge("Alice@Gmail.com").unwrap();
+        assert_eq!(verified.verified_at, verifier.now);
+        assert!(!format!("{verified:?}").contains("private"));
+    }
+}

--- a/crates/satspath-core/src/pointer.rs
+++ b/crates/satspath-core/src/pointer.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use url::form_urlencoded;
 
 use crate::errors::{Result, SatsPathError};
+use crate::profile::ClaimPolicy;
 use crate::validation::{assert_no_private_material, validate_amount_sats};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -23,7 +24,6 @@ pub enum PaymentPointer {
     },
     LnurlPay {
         callback_url: String,
-        metadata_hash: Option<String>,
         receiver_pubkey: Option<String>,
     },
     Bolt11Invoice {
@@ -33,7 +33,7 @@ pub enum PaymentPointer {
     OnchainAddress {
         network: BitcoinNetwork,
         address: String,
-        derivation_hint: Option<String>,
+        claim_policy: Option<ClaimPolicy>,
     },
     Ark {
         server: String,
@@ -74,6 +74,14 @@ pub fn build_qr_payload(pointer: &PaymentPointer, amount_sats: u64) -> Result<St
             url.query_pairs_mut()
                 .append_pair("amount", &amount_msats.to_string());
             url.to_string()
+        }
+        PaymentPointer::Bolt11Invoice {
+            invoice,
+            amount_sats: Some(invoice_amount),
+        } if *invoice_amount != amount_sats => {
+            return Err(SatsPathError::InvalidPaymentPointer(format!(
+                "BOLT11 amount mismatch: invoice={invoice_amount} sats request={amount_sats} sats"
+            )));
         }
         PaymentPointer::Bolt11Invoice { invoice, .. } => invoice.clone(),
         PaymentPointer::OnchainAddress { address, .. } => {
@@ -132,7 +140,7 @@ mod tests {
         let pointer = PaymentPointer::OnchainAddress {
             network: BitcoinNetwork::Mainnet,
             address: "1BoatSLRHtKNngkdXEeobR76b53LETtpyT".into(),
-            derivation_hint: None,
+            claim_policy: None,
         };
         assert_eq!(
             build_qr_payload(&pointer, 21_000).unwrap(),
@@ -161,5 +169,14 @@ mod tests {
             amount_sats: Some(1),
         };
         assert!(build_qr_payload(&pointer, 1).is_err());
+    }
+
+    #[test]
+    fn bolt11_amount_mismatch_fails() {
+        let pointer = PaymentPointer::Bolt11Invoice {
+            invoice: "lnbc210n1pexampleinvoice".into(),
+            amount_sats: Some(21_000),
+        };
+        assert!(build_qr_payload(&pointer, 1_000).is_err());
     }
 }

--- a/crates/satspath-core/src/profile.rs
+++ b/crates/satspath-core/src/profile.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::pointer::BitcoinNetwork;
+
 /// A single payment method supported by the profile owner.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
@@ -7,22 +9,38 @@ pub enum PaymentMethod {
     /// On-chain Bitcoin. Multiple entries are encouraged for privacy.
     Onchain {
         label: String,
+        #[serde(default = "default_bitcoin_network")]
+        network: BitcoinNetwork,
         address: String,
+        #[serde(default)]
         pubkey_hint: Option<String>,
+        #[serde(default)]
+        descriptor_hint: Option<String>,
     },
     /// Lightning Network via LNURL, Lightning Address, or BOLT12.
     Lightning {
         label: String,
-        lnurl: Option<String>,
+        #[serde(default)]
         lightning_address: Option<String>,
+        #[serde(default)]
+        lnurl: Option<String>,
+        #[serde(default)]
         bolt12: Option<String>,
+        #[serde(default)]
+        receiver_pubkey: Option<String>,
     },
     /// Ark virtual UTXO protocol.
     Ark {
         label: String,
         server: String,
         pubkey: String,
+        #[serde(default)]
+        vtxo_pointer: Option<String>,
     },
+}
+
+fn default_bitcoin_network() -> BitcoinNetwork {
+    BitcoinNetwork::Mainnet
 }
 
 impl PaymentMethod {
@@ -54,6 +72,9 @@ pub struct PaymentProfile {
     pub methods: Vec<PaymentMethod>,
     /// Unix timestamp of last update
     pub updated_at: i64,
+    /// Unix timestamp after which resolvers should treat this profile as stale.
+    #[serde(default)]
+    pub expires_at: Option<i64>,
 }
 
 /// A payment profile together with the owner's signature over its contents.
@@ -83,4 +104,44 @@ pub struct Invite {
     pub created_at: i64,
     pub claim_url: String,
     pub warning: String,
+}
+
+/// Non-custodial invite state for an identifier with no published profile yet.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InviteRecord {
+    pub invite_id: String,
+    pub identifier_hash: String,
+    pub display_hint: String,
+    pub amount_sats: u64,
+    pub memo: Option<String>,
+    pub sender_fingerprint: String,
+    pub status: InviteStatus,
+    pub created_at: i64,
+    pub expires_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum InviteStatus {
+    Created,
+    EmailSent,
+    ClaimedWithPublicProfile,
+    Expired,
+    Cancelled,
+}
+
+/// Public claim policy metadata only. It is never sufficient to spend funds.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ClaimPolicy {
+    SingleSig {
+        receiver_pubkey: String,
+    },
+    Multisig {
+        threshold: u8,
+        pubkeys: Vec<String>,
+        descriptor: Option<String>,
+    },
+    FutureTaproot {
+        internal_key: String,
+        script_policy_hint: Option<String>,
+    },
 }

--- a/crates/satspath-core/src/registry.rs
+++ b/crates/satspath-core/src/registry.rs
@@ -116,11 +116,13 @@ mod tests {
             identity_pubkey: pubkey_hex,
             methods: vec![PaymentMethod::Lightning {
                 label: "LN".into(),
-                lnurl: None,
                 lightning_address: Some(alias.to_string()),
+                lnurl: None,
                 bolt12: None,
+                receiver_pubkey: None,
             }],
             updated_at: 1_700_000_000,
+            expires_at: None,
         };
         sign_profile(profile, &kp.secret_key).unwrap()
     }

--- a/crates/satspath-core/src/resolver.rs
+++ b/crates/satspath-core/src/resolver.rs
@@ -38,25 +38,16 @@ impl ChainResolver {
 #[async_trait]
 impl ProfileResolver for ChainResolver {
     async fn resolve_alias(&self, alias: &str) -> Result<SignedPaymentProfile> {
-        let mut last_error = None;
-
         for resolver in &self.resolvers {
             match resolver.resolve_alias(alias).await {
                 Ok(profile) => return Ok(profile),
                 Err(SatsPathError::AliasNotFound(_)) => continue,
-                Err(e) => {
-                    // Save the error, but keep trying the next resolver
-                    last_error = Some(e);
-                    continue;
-                }
+                Err(SatsPathError::NetworkError(_)) => continue,
+                Err(e) => return Err(e),
             }
         }
 
-        if let Some(e) = last_error {
-            Err(e)
-        } else {
-            Err(SatsPathError::AliasNotFound(alias.to_string()))
-        }
+        Err(SatsPathError::AliasNotFound(alias.to_string()))
     }
 }
 
@@ -81,11 +72,13 @@ mod tests {
                     identity_pubkey: pubkey_hex,
                     methods: vec![PaymentMethod::Lightning {
                         label: "LN".into(),
-                        lnurl: None,
                         lightning_address: Some(alias.to_string()),
+                        lnurl: None,
                         bolt12: None,
+                        receiver_pubkey: None,
                     }],
                     updated_at: 1_700_000_000,
+                    expires_at: None,
                 };
                 Ok(sign_profile(profile, &kp.secret_key).unwrap())
             } else {

--- a/crates/satspath-core/src/resolvers/bip353.rs
+++ b/crates/satspath-core/src/resolvers/bip353.rs
@@ -1,0 +1,37 @@
+use async_trait::async_trait;
+
+use crate::resolver::ProfileResolver;
+use crate::{Result, SatsPathError, SignedPaymentProfile};
+
+pub struct Bip353Resolver {
+    dnssec_required: bool,
+}
+
+impl Bip353Resolver {
+    pub fn new() -> Self {
+        Self {
+            dnssec_required: true,
+        }
+    }
+
+    pub fn dnssec_required(&self) -> bool {
+        self.dnssec_required
+    }
+}
+
+#[async_trait]
+impl ProfileResolver for Bip353Resolver {
+    async fn resolve_alias(&self, alias: &str) -> Result<SignedPaymentProfile> {
+        if !alias.starts_with('₿') {
+            return Err(SatsPathError::AliasNotFound(alias.to_string()));
+        }
+        Err(SatsPathError::InvalidRoute(
+            "BIP-353 DNSSEC validation is not implemented; failing closed".into(),
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Bip321PaymentUri {
+    pub uri: String,
+}

--- a/crates/satspath-core/src/resolvers/mod.rs
+++ b/crates/satspath-core/src/resolvers/mod.rs
@@ -1,1 +1,4 @@
+pub mod bip353;
 pub mod http;
+pub mod nostr;
+pub mod platform;

--- a/crates/satspath-core/src/resolvers/nostr.rs
+++ b/crates/satspath-core/src/resolvers/nostr.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+
+use crate::resolver::ProfileResolver;
+use crate::{Result, SatsPathError, SignedPaymentProfile};
+
+pub struct NostrResolver;
+
+#[async_trait]
+impl ProfileResolver for NostrResolver {
+    async fn resolve_alias(&self, alias: &str) -> Result<SignedPaymentProfile> {
+        Err(SatsPathError::AliasNotFound(format!(
+            "Nostr resolver scaffold only: {alias}"
+        )))
+    }
+}

--- a/crates/satspath-core/src/resolvers/platform.rs
+++ b/crates/satspath-core/src/resolvers/platform.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+
+use crate::resolver::ProfileResolver;
+use crate::{Result, SatsPathError, SignedPaymentProfile};
+
+pub struct PlatformApiResolver {
+    pub base_url: String,
+}
+
+#[async_trait]
+impl ProfileResolver for PlatformApiResolver {
+    async fn resolve_alias(&self, alias: &str) -> Result<SignedPaymentProfile> {
+        let _ = &self.base_url;
+        Err(SatsPathError::AliasNotFound(format!(
+            "platform API resolver scaffold only: {alias}"
+        )))
+    }
+}

--- a/crates/satspath-core/src/validation.rs
+++ b/crates/satspath-core/src/validation.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use crate::errors::{Result, SatsPathError};
 use crate::pointer::BitcoinNetwork;
+use crate::profile::{ClaimPolicy, PaymentMethod, PaymentProfile};
 
 pub const LARGE_PREVIEW_AMOUNT_SATS: u64 = 100_000_000;
 pub const MAX_PREVIEW_AMOUNT_SATS: u64 = 21_000_000 * 100_000_000;
@@ -107,6 +108,115 @@ pub fn assert_no_private_material(payload: &str) -> Result<()> {
     Ok(())
 }
 
+pub fn validate_claim_policy(policy: &ClaimPolicy) -> Result<()> {
+    match policy {
+        ClaimPolicy::SingleSig { receiver_pubkey } => validate_compressed_pubkey(receiver_pubkey),
+        ClaimPolicy::Multisig {
+            threshold,
+            pubkeys,
+            descriptor,
+        } => {
+            if *threshold == 0 || usize::from(*threshold) > pubkeys.len() {
+                return Err(SatsPathError::InvalidPaymentPointer(
+                    "invalid multisig threshold".into(),
+                ));
+            }
+            for pubkey in pubkeys {
+                validate_compressed_pubkey(pubkey)?;
+            }
+            if let Some(descriptor) = descriptor {
+                assert_no_private_material(descriptor)?;
+            }
+            Ok(())
+        }
+        ClaimPolicy::FutureTaproot {
+            internal_key,
+            script_policy_hint,
+        } => {
+            validate_compressed_pubkey(internal_key)?;
+            if let Some(hint) = script_policy_hint {
+                assert_no_private_material(hint)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+pub fn validate_public_profile(profile: &PaymentProfile) -> Result<()> {
+    assert_no_private_material(&profile.alias)?;
+    validate_compressed_pubkey(&profile.identity_pubkey)?;
+    if let Some(expires_at) = profile.expires_at {
+        if expires_at <= profile.updated_at {
+            return Err(SatsPathError::InvalidPaymentPointer(
+                "profile expires before it is updated".into(),
+            ));
+        }
+    }
+
+    for method in &profile.methods {
+        match method {
+            PaymentMethod::Lightning {
+                lightning_address,
+                lnurl,
+                bolt12,
+                receiver_pubkey,
+                ..
+            } => {
+                if let Some(address) = lightning_address {
+                    validate_lightning_address(address)?;
+                }
+                if let Some(url) = lnurl {
+                    let parsed = url::Url::parse(url)
+                        .map_err(|e| SatsPathError::InvalidPaymentPointer(e.to_string()))?;
+                    if !matches!(parsed.scheme(), "https" | "http") {
+                        return Err(SatsPathError::InvalidPaymentPointer(
+                            "LNURL must be http(s)".into(),
+                        ));
+                    }
+                }
+                if let Some(invoice) = bolt12 {
+                    assert_no_private_material(invoice)?;
+                }
+                if let Some(pubkey) = receiver_pubkey {
+                    validate_compressed_pubkey(pubkey)?;
+                }
+            }
+            PaymentMethod::Onchain {
+                network,
+                address,
+                pubkey_hint,
+                descriptor_hint,
+                ..
+            } => {
+                validate_bitcoin_address(address, *network)?;
+                if let Some(pubkey) = pubkey_hint {
+                    validate_compressed_pubkey(pubkey)?;
+                }
+                if let Some(descriptor) = descriptor_hint {
+                    assert_no_private_material(descriptor)?;
+                }
+            }
+            PaymentMethod::Ark {
+                server,
+                pubkey,
+                vtxo_pointer,
+                ..
+            } => {
+                if server.trim().is_empty() {
+                    return Err(SatsPathError::InvalidPaymentPointer(
+                        "Ark server is required".into(),
+                    ));
+                }
+                validate_compressed_pubkey(pubkey)?;
+                if let Some(vtxo) = vtxo_pointer {
+                    assert_no_private_material(vtxo)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,5 +255,33 @@ mod tests {
     fn lightning_address_parsed() {
         assert!(validate_lightning_address("rodrigo@example.com").is_ok());
         assert!(validate_lightning_address("not-an-address").is_err());
+    }
+
+    #[test]
+    fn profile_rejects_private_material() {
+        let profile = PaymentProfile {
+            alias: "alice@example.com".into(),
+            identity_pubkey: VALID_PUBKEY.into(),
+            methods: vec![PaymentMethod::Lightning {
+                label: "LN".into(),
+                lightning_address: Some("alice@example.com".into()),
+                lnurl: None,
+                bolt12: Some("secret xprv payload".into()),
+                receiver_pubkey: None,
+            }],
+            updated_at: 1,
+            expires_at: Some(2),
+        };
+        assert!(validate_public_profile(&profile).is_err());
+    }
+
+    #[test]
+    fn multisig_claim_policy_validates_pubkeys() {
+        let policy = ClaimPolicy::Multisig {
+            threshold: 2,
+            pubkeys: vec![VALID_PUBKEY.into(), VALID_PUBKEY.into()],
+            descriptor: Some("wsh(sortedmulti(2,...))".into()),
+        };
+        assert!(validate_claim_policy(&policy).is_ok());
     }
 }

--- a/crates/satspath-router/src/lib.rs
+++ b/crates/satspath-router/src/lib.rs
@@ -3,8 +3,12 @@ pub mod fees;
 pub mod lightning;
 pub mod onchain;
 pub mod router;
+pub mod scoring;
 
 pub use lightning::{fetch_invoice, fetch_lnurl_metadata, LnurlPayMetadata};
 pub use router::{
     select_route, select_route_with_fees, FeeRateSnapshot, RouteQuote, RouteRequest, SwapDirective,
+};
+pub use scoring::{
+    score_routes, FeeSnapshot, PaymentRail, RouteCandidate, RouteDecision, RoutePreferences,
 };

--- a/crates/satspath-router/src/router.rs
+++ b/crates/satspath-router/src/router.rs
@@ -245,7 +245,7 @@ mod tests {
     use super::*;
     use satspath_core::{
         crypto::{generate_identity_keypair, sign_profile},
-        PaymentMethod, PaymentProfile,
+        BitcoinNetwork, PaymentMethod, PaymentProfile,
     };
 
     fn low_fees() -> FeeEstimate {
@@ -276,6 +276,7 @@ mod tests {
             identity_pubkey: pubkey_hex,
             methods,
             updated_at: 1_700_000_000,
+            expires_at: None,
         };
         sign_profile(profile, &kp.secret_key).unwrap()
     }
@@ -284,9 +285,10 @@ mod tests {
     fn chooses_lightning_for_small_amount() {
         let signed = make_profile(vec![PaymentMethod::Lightning {
             label: "LN".into(),
-            lnurl: None,
             lightning_address: Some("test@example.com".into()),
+            lnurl: None,
             bolt12: None,
+            receiver_pubkey: None,
         }]);
         let req = RouteRequest {
             alias: "test@example.com".into(),
@@ -302,9 +304,10 @@ mod tests {
         // Even with extreme fees, Lightning for small amounts must still win.
         let signed = make_profile(vec![PaymentMethod::Lightning {
             label: "LN".into(),
-            lnurl: None,
             lightning_address: Some("test@example.com".into()),
+            lnurl: None,
             bolt12: None,
+            receiver_pubkey: None,
         }]);
         let extreme_fees = FeeEstimate {
             fastest_fee: 500,
@@ -326,8 +329,10 @@ mod tests {
     fn chooses_onchain_for_large_amount_low_fees() {
         let signed = make_profile(vec![PaymentMethod::Onchain {
             label: "BTC".into(),
+            network: BitcoinNetwork::Mainnet,
             address: "bc1q...".into(),
             pubkey_hint: None,
+            descriptor_hint: None,
         }]);
         let req = RouteRequest {
             alias: "test@example.com".into(),
@@ -344,13 +349,16 @@ mod tests {
         let signed = make_profile(vec![
             PaymentMethod::Onchain {
                 label: "BTC".into(),
+                network: BitcoinNetwork::Mainnet,
                 address: "bc1q...".into(),
                 pubkey_hint: None,
+                descriptor_hint: None,
             },
             PaymentMethod::Ark {
                 label: "Ark".into(),
                 server: "ark.example.com".into(),
                 pubkey: "aabbcc".into(),
+                vtxo_pointer: None,
             },
         ]);
         let req = RouteRequest {
@@ -381,8 +389,10 @@ mod tests {
     fn onchain_boundary_at_20_sat_vb() {
         let signed = make_profile(vec![PaymentMethod::Onchain {
             label: "BTC".into(),
+            network: BitcoinNetwork::Mainnet,
             address: "bc1q...".into(),
             pubkey_hint: None,
+            descriptor_hint: None,
         }]);
         let req = RouteRequest {
             alias: "test@example.com".into(),

--- a/crates/satspath-router/src/scoring.rs
+++ b/crates/satspath-router/src/scoring.rs
@@ -1,0 +1,358 @@
+use satspath_core::{PaymentMethod, PaymentPointer, Result, SatsPathError, SignedPaymentProfile};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaymentRail {
+    Lightning,
+    Onchain,
+    Ark,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteCandidate {
+    pub rail: PaymentRail,
+    pub estimated_fee_sats: Option<u64>,
+    pub estimated_time_seconds: Option<u64>,
+    pub privacy_score: u8,
+    pub reliability_score: u8,
+    pub requires_user_action: bool,
+    pub available: bool,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FeeSnapshot {
+    pub lightning_fee_sats_estimate: Option<u64>,
+    pub onchain_fastest_sat_vb: Option<u64>,
+    pub onchain_half_hour_sat_vb: Option<u64>,
+    pub onchain_hour_sat_vb: Option<u64>,
+    pub ark_fee_sats_estimate: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoutePreferences {
+    pub prefer_low_fee: bool,
+    pub prefer_speed: bool,
+    pub prefer_privacy: bool,
+    pub allow_experimental_ark: bool,
+    pub max_fee_sats: Option<u64>,
+}
+
+impl Default for RoutePreferences {
+    fn default() -> Self {
+        Self {
+            prefer_low_fee: true,
+            prefer_speed: true,
+            prefer_privacy: false,
+            allow_experimental_ark: false,
+            max_fee_sats: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteDecision {
+    pub selected: RouteCandidate,
+    pub alternatives: Vec<RouteCandidate>,
+    pub payment_pointer: PaymentPointer,
+    pub explanation: String,
+}
+
+pub fn score_routes(
+    amount_sats: u64,
+    profile: &SignedPaymentProfile,
+    fee_snapshot: &FeeSnapshot,
+    preferences: &RoutePreferences,
+) -> Result<RouteDecision> {
+    let mut candidates = Vec::new();
+    let mut pointers = Vec::new();
+
+    for method in &profile.profile.methods {
+        match method {
+            PaymentMethod::Lightning {
+                lightning_address,
+                lnurl,
+                bolt12,
+                receiver_pubkey,
+                ..
+            } => {
+                let fee = fee_snapshot
+                    .lightning_fee_sats_estimate
+                    .unwrap_or_else(|| std::cmp::max(1, amount_sats / 10_000));
+                let available = lightning_address.is_some() || lnurl.is_some() || bolt12.is_some();
+                let pointer = if let Some(address) = lightning_address {
+                    PaymentPointer::LightningAddress {
+                        address: address.clone(),
+                        receiver_pubkey: receiver_pubkey.clone(),
+                    }
+                } else if let Some(callback_url) = lnurl {
+                    PaymentPointer::LnurlPay {
+                        callback_url: callback_url.clone(),
+                        receiver_pubkey: receiver_pubkey.clone(),
+                    }
+                } else if let Some(invoice) = bolt11_like(bolt12.as_deref()) {
+                    PaymentPointer::Bolt11Invoice {
+                        invoice: invoice.to_string(),
+                        amount_sats: Some(amount_sats),
+                    }
+                } else {
+                    continue;
+                };
+                candidates.push(RouteCandidate {
+                    rail: PaymentRail::Lightning,
+                    estimated_fee_sats: Some(fee),
+                    estimated_time_seconds: Some(5),
+                    privacy_score: 7,
+                    reliability_score: 8,
+                    requires_user_action: true,
+                    available,
+                    reason: "Lightning available for low-latency payment pointer.".into(),
+                });
+                pointers.push(pointer);
+            }
+            PaymentMethod::Onchain {
+                network,
+                address,
+                descriptor_hint,
+                ..
+            } => {
+                let sats_per_vb = fee_snapshot
+                    .onchain_fastest_sat_vb
+                    .or(fee_snapshot.onchain_half_hour_sat_vb)
+                    .or(fee_snapshot.onchain_hour_sat_vb);
+                let fee = sats_per_vb.map(|rate| rate * 141);
+                let dust = amount_sats < 546;
+                let policy_complexity = policy_complexity_hint(descriptor_hint.as_deref());
+                candidates.push(RouteCandidate {
+                    rail: PaymentRail::Onchain,
+                    estimated_fee_sats: fee,
+                    estimated_time_seconds: Some(600),
+                    privacy_score: 4,
+                    reliability_score: 10u8.saturating_sub(policy_complexity),
+                    requires_user_action: true,
+                    available: !dust && fee.is_some(),
+                    reason: if dust {
+                        "Amount is dust/economically irrational for on-chain output.".into()
+                    } else if policy_complexity > 1 {
+                        "On-chain address available with public policy complexity hint.".into()
+                    } else {
+                        "On-chain address available; fee depends on mempool.".into()
+                    },
+                });
+                pointers.push(PaymentPointer::OnchainAddress {
+                    network: *network,
+                    address: address.clone(),
+                    claim_policy: None,
+                });
+            }
+            PaymentMethod::Ark {
+                server,
+                pubkey,
+                vtxo_pointer,
+                ..
+            } => {
+                let available = preferences.allow_experimental_ark;
+                candidates.push(RouteCandidate {
+                    rail: PaymentRail::Ark,
+                    estimated_fee_sats: fee_snapshot.ark_fee_sats_estimate.or(Some(1)),
+                    estimated_time_seconds: Some(30),
+                    privacy_score: 8,
+                    reliability_score: if available { 5 } else { 2 },
+                    requires_user_action: true,
+                    available,
+                    reason: if available {
+                        "Ark pointer available; experimental route allowed.".into()
+                    } else {
+                        "Ark pointer available but experimental Ark is disabled.".into()
+                    },
+                });
+                pointers.push(PaymentPointer::Ark {
+                    server: server.clone(),
+                    receiver_pubkey: pubkey.clone(),
+                    vtxo_pointer: vtxo_pointer.clone(),
+                });
+            }
+        }
+    }
+
+    let selected_index = candidates
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| c.available)
+        .filter(|(_, c)| {
+            preferences
+                .max_fee_sats
+                .map(|max| c.estimated_fee_sats.unwrap_or(u64::MAX) <= max)
+                .unwrap_or(true)
+        })
+        .max_by_key(|(_, c)| candidate_score(c, preferences, amount_sats))
+        .map(|(idx, _)| idx)
+        .ok_or_else(|| SatsPathError::NoRouteFound("no available scored route".into()))?;
+
+    let selected = candidates[selected_index].clone();
+    let payment_pointer = pointers[selected_index].clone();
+    let alternatives = candidates
+        .into_iter()
+        .enumerate()
+        .filter_map(|(idx, candidate)| (idx != selected_index).then_some(candidate))
+        .collect();
+    let explanation = format!(
+        "Selected {:?}: {} Fee: {:?}, ETA: {:?}.",
+        selected.rail,
+        selected.reason,
+        selected.estimated_fee_sats,
+        selected.estimated_time_seconds
+    );
+
+    Ok(RouteDecision {
+        selected,
+        alternatives,
+        payment_pointer,
+        explanation,
+    })
+}
+
+fn candidate_score(
+    candidate: &RouteCandidate,
+    preferences: &RoutePreferences,
+    amount_sats: u64,
+) -> i64 {
+    let mut score = 0i64;
+    score += i64::from(candidate.reliability_score) * 10;
+    score += i64::from(candidate.privacy_score) * if preferences.prefer_privacy { 8 } else { 2 };
+    if preferences.prefer_speed {
+        score -= candidate.estimated_time_seconds.unwrap_or(3_600) as i64 / 30;
+    }
+    if preferences.prefer_low_fee {
+        score -= candidate.estimated_fee_sats.unwrap_or(10_000) as i64 / 10;
+    }
+    if candidate.rail == PaymentRail::Lightning && amount_sats <= 1_000_000 {
+        score += 30;
+    }
+    if candidate.rail == PaymentRail::Onchain && amount_sats >= 1_000_000 {
+        score += 20;
+    }
+    if candidate.rail == PaymentRail::Ark && !preferences.allow_experimental_ark {
+        score -= 1_000;
+    }
+    score
+}
+
+fn bolt11_like(value: Option<&str>) -> Option<&str> {
+    value.filter(|invoice| invoice.starts_with("lnbc") || invoice.starts_with("lntb"))
+}
+
+fn policy_complexity_hint(descriptor_hint: Option<&str>) -> u8 {
+    let Some(hint) = descriptor_hint else {
+        return 1;
+    };
+    let lower = hint.to_ascii_lowercase();
+    if lower.contains("multi") {
+        3
+    } else if lower.contains("tr(") || lower.contains("taproot") {
+        2
+    } else {
+        1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use satspath_core::{
+        crypto::{generate_identity_keypair, sign_profile},
+        BitcoinNetwork, PaymentProfile,
+    };
+
+    fn signed(methods: Vec<PaymentMethod>) -> SignedPaymentProfile {
+        let kp = generate_identity_keypair();
+        let profile = PaymentProfile {
+            alias: "alice@example.com".into(),
+            identity_pubkey: hex::encode(kp.public_key.serialize()),
+            methods,
+            updated_at: 1,
+            expires_at: None,
+        };
+        sign_profile(profile, &kp.secret_key).unwrap()
+    }
+
+    #[test]
+    fn lightning_route_selected_for_small_amount() {
+        let profile = signed(vec![PaymentMethod::Lightning {
+            label: "LN".into(),
+            lightning_address: Some("alice@example.com".into()),
+            lnurl: None,
+            bolt12: None,
+            receiver_pubkey: None,
+        }]);
+        let decision = score_routes(
+            1_000,
+            &profile,
+            &FeeSnapshot::default(),
+            &RoutePreferences::default(),
+        )
+        .unwrap();
+        assert_eq!(decision.selected.rail, PaymentRail::Lightning);
+    }
+
+    #[test]
+    fn onchain_selected_when_large_and_fee_acceptable() {
+        let profile = signed(vec![PaymentMethod::Onchain {
+            label: "BTC".into(),
+            network: BitcoinNetwork::Mainnet,
+            address: "1BoatSLRHtKNngkdXEeobR76b53LETtpyT".into(),
+            pubkey_hint: None,
+            descriptor_hint: None,
+        }]);
+        let fees = FeeSnapshot {
+            onchain_fastest_sat_vb: Some(2),
+            ..FeeSnapshot::default()
+        };
+        let decision =
+            score_routes(2_000_000, &profile, &fees, &RoutePreferences::default()).unwrap();
+        assert_eq!(decision.selected.rail, PaymentRail::Onchain);
+    }
+
+    #[test]
+    fn onchain_policy_complexity_affects_reason() {
+        let profile = signed(vec![PaymentMethod::Onchain {
+            label: "BTC".into(),
+            network: BitcoinNetwork::Mainnet,
+            address: "1BoatSLRHtKNngkdXEeobR76b53LETtpyT".into(),
+            pubkey_hint: None,
+            descriptor_hint: Some("wsh(sortedmulti(2,...))".into()),
+        }]);
+        let fees = FeeSnapshot {
+            onchain_fastest_sat_vb: Some(2),
+            ..FeeSnapshot::default()
+        };
+        let decision =
+            score_routes(2_000_000, &profile, &fees, &RoutePreferences::default()).unwrap();
+        assert!(decision.selected.reason.contains("policy complexity"));
+    }
+
+    #[test]
+    fn ark_selected_only_when_allowed() {
+        let valid_pubkey = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+        let profile = signed(vec![PaymentMethod::Ark {
+            label: "Ark".into(),
+            server: "https://ark.example.com".into(),
+            pubkey: valid_pubkey.into(),
+            vtxo_pointer: None,
+        }]);
+        assert!(score_routes(
+            1_000,
+            &profile,
+            &FeeSnapshot::default(),
+            &RoutePreferences::default()
+        )
+        .is_err());
+
+        let preferences = RoutePreferences {
+            allow_experimental_ark: true,
+            ..RoutePreferences::default()
+        };
+        let decision =
+            score_routes(1_000, &profile, &FeeSnapshot::default(), &preferences).unwrap();
+        assert_eq!(decision.selected.rail, PaymentRail::Ark);
+    }
+}

--- a/docs/identity_ownership_model.md
+++ b/docs/identity_ownership_model.md
@@ -1,0 +1,58 @@
+# Identity Ownership Model
+
+SatsPath maps human identifiers to signed public payment profiles. The proof
+attached to an identifier depends on the identifier type.
+
+## Domain-Owned Identifier
+
+Example:
+
+```txt
+₿rodrigo@satspath.dev
+```
+
+A domain-owned identifier can be verified through DNS-based mechanisms such as
+BIP-353 and DNSSEC when the domain owner publishes payment instructions. This is
+the preferred protocol-native ownership model because the user or wallet
+operator controls the domain namespace.
+
+SatsPath must fail closed when DNSSEC validation is required but not available.
+The current BIP-353 resolver is a scaffold and does not claim full DNSSEC
+validation.
+
+## Platform-Verified Email
+
+Example:
+
+```txt
+rodrigo@gmail.com
+```
+
+For Gmail-style addresses, SatsPath cannot prove domain ownership through DNS.
+A hosted SatsPath platform can only prove inbox access by sending a code or magic
+link to that email address.
+
+Email verification means:
+
+- the receiver accessed the inbox,
+- the receiver can proceed to create or connect a wallet,
+- the receiver wallet can publish a signed public profile.
+
+Email verification does not mean:
+
+- SatsPath controls the domain,
+- SatsPath owns the wallet,
+- custody moved,
+- private keys or seed phrases were transferred.
+
+## Local Contact
+
+A local contact is an alias stored on the local device. It is trusted only by
+that local user/device. It is useful for demos, contacts, and local registry
+fallbacks, but it is not global identity proof.
+
+## Privacy Note
+
+Identifier hashes are used where possible, but hashed emails are not strong
+anonymity because emails are guessable. Platform layers should avoid storing raw
+emails except where delivery is required.

--- a/docs/invite_flow.md
+++ b/docs/invite_flow.md
@@ -1,0 +1,28 @@
+# Invite Flow
+
+Unknown receiver flow:
+
+```txt
+identifier -> no signed profile -> create invite -> receiver verifies email -> receiver wallet generates keys locally -> receiver publishes signed public profile -> sender re-resolves -> payment can proceed
+```
+
+Rules:
+
+- Unknown receiver means invite only.
+- No funds move before the receiver publishes a signed public payment profile.
+- SatsPath does not generate seed phrases.
+- SatsPath does not generate wallet private keys.
+- SatsPath does not email private material.
+- Email verification proves inbox access, not domain ownership.
+
+Email content should say:
+
+```txt
+Someone wants to send you Bitcoin through SatsPath.
+Click Receive to create or connect a wallet.
+Your wallet will generate keys locally.
+SatsPath will never see your seed or private keys.
+```
+
+Invite records store public routing metadata and identifier hashes. If raw email
+is needed for delivery, it belongs only in the platform layer and should expire.

--- a/docs/mainnet_safety.md
+++ b/docs/mainnet_safety.md
@@ -8,6 +8,10 @@ SatsPath is a powerful routing engine that coordinates interactions across multi
 - The `Identity Key` (used to sign profiles) **does not** control funds.
 - Wallet, Node, or SDK plugins are responsible for securely managing funds and signing transactions.
 - Never store seed phrases, wallet private keys, macaroons, certs, API tokens, or other high-value secrets in the SatsPath repository or plaintext config files.
+- Email verification proves inbox access only. It does not transfer custody and
+  does not prove ownership of a Gmail-style domain.
+- Receiver wallets must generate private keys locally on the receiver's device
+  and publish only public payment profiles.
 
 ## 2. Mainnet Configuration
 
@@ -19,7 +23,10 @@ By default, the SatsPath Swap Engine operates in **Testnet mode**.
 - `require_manual_confirmation = true`
 - `fail_closed = true`
 
-Mainnet execution requires explicit confirmation via the CLI (`--experimental-swaps --testnet` are for testing only; mainnet will require a different explicit flag once enabled).
+Mainnet preview is allowed because it touches public data only. Mainnet
+execution is disabled. `--experimental-swaps --testnet` is for testnet-only
+engine scaffolding; mainnet execution requires a separate future feature with
+stronger confirmation gates.
 
 ## 3. Strict Pre-Execution Checks
 

--- a/docs/routing_model.md
+++ b/docs/routing_model.md
@@ -1,0 +1,41 @@
+# Routing Model
+
+SatsPath compares Lightning, on-chain Bitcoin, and Ark using public profile
+data, fee estimates, and user preferences.
+
+`RouteCandidate` includes:
+
+- rail,
+- estimated fee,
+- estimated time,
+- privacy score,
+- reliability score,
+- user action requirement,
+- availability,
+- reason.
+
+## MVP Rules
+
+Lightning:
+
+- preferred for small and medium amounts when available,
+- uses conservative fee heuristics,
+- does not query private node data unless explicitly configured.
+
+On-chain:
+
+- estimates fee as vbytes multiplied by sat/vB,
+- rejects dust or economically irrational outputs,
+- preferred for large amounts or when Lightning is unavailable.
+
+Ark:
+
+- experimental,
+- considered when an Ark public pointer exists,
+- selected only when experimental Ark is allowed,
+- no mainnet settlement in SatsPath.
+
+## Execution Boundary
+
+Route selection produces a payment pointer and explanation. It does not sign,
+broadcast, settle, or move funds.

--- a/docs/satspath_protocol.md
+++ b/docs/satspath_protocol.md
@@ -1,0 +1,55 @@
+# SatsPath Protocol
+
+SatsPath is an open Bitcoin payment resolver and routing protocol. Wallets can
+implement it without using a SatsPath-hosted platform.
+
+The protocol flow is:
+
+```txt
+identifier -> signed public profile -> public payment pointers -> route decision -> QR/payment intent
+```
+
+## Public Profile
+
+A `PaymentProfile` contains public information only:
+
+- identifier alias,
+- identity public key,
+- Lightning Address, LNURL, or BOLT-style public invoice data,
+- on-chain public addresses and public descriptor hints,
+- Ark server and receiver public key,
+- update and expiry timestamps.
+
+The profile is signed by the user's identity key. That identity key does not
+control funds by itself. Wallets and nodes control funds.
+
+## Payment Pointers
+
+`PaymentPointer` is the stable output from resolution/routing. It may contain:
+
+- Lightning Address,
+- LNURL-pay callback,
+- BOLT11 invoice as data,
+- Bitcoin address with public claim policy metadata,
+- Ark public pointer.
+
+It must never contain private keys, seed phrases, macaroons, certificates, API
+secrets, or signing keys.
+
+## Platform
+
+The SatsPath Platform is optional. It can provide:
+
+- email verification for normal users,
+- invite links,
+- API-based profile publishing,
+- public profile lookup.
+
+It must never custody funds and must never see wallet private keys.
+
+## Compatibility
+
+BIP-353 discovers payment instructions through DNS. BIP-321/BIP-21 style
+`bitcoin:` URIs encode payment instructions. SatsPath extends this by adding
+signed public profiles and route selection across Lightning, on-chain Bitcoin,
+and Ark.


### PR DESCRIPTION
## Summary

Evolves SatsPath toward the open Bitcoin payment resolver/routing protocol model:

- expands public signed profile and payment pointer types with public-only metadata
- adds invite records, email verification interfaces, profile publishing interfaces, and resolver scaffolds
- adds BIP-353/Nostr/platform resolver scaffolds with BIP-353 fail-closed behavior
- adds route scoring across Lightning, on-chain, and Ark
- routes unknown users in `satspath pay` into invite preview instead of payment execution
- documents identity ownership, invite flow, routing model, protocol/platform split, and mainnet safety

## Safety

SatsPath still does not generate, store, email, recover, sign with, or broadcast using private keys or seed phrases. Mainnet execution remains disabled. Experimental swap execution remains testnet-only behind explicit flags.

## Validation

- `cargo fmt --check`
- `cargo test`
- demo flow verified
- unknown user `satspath pay someone@gmail.com 1000` creates an invite and prints `No funds moved.`