### PR TITLE
feat: add Ark send/receive route planning and testnet-gated swap intents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt --all -- --check
+      - run: cargo test --workspace --all-targets
+      - run: cargo clippy --workspace --all-targets -- -D warnings

--- a/README.md
+++ b/README.md
@@ -31,15 +31,17 @@ layer — not a wallet, not a custodian.
 - Encode/decode universal payment URIs (`satspath:v1:<base64url_json>`).
 - Sign profiles with secp256k1 identity keys.
 - Verify profile signatures before routing.
-- Select the best payment rail (Lightning → On-chain → Ark).
+- Select the best payment rail (Lightning → On-chain → Ark preview/intents).
 - Fetch real-time on-chain fee estimates from mempool.space.
-- Simulate payment execution on the selected rail.
+- Generate safe payment previews and Ark route intents; Ark swaps are not claimed
+  as complete unless explicitly testnet-executed and supported by the bridge.
 - Generate invite links for unregistered users (receiver generates their own keys).
 - Full CLI: `init`, `register`, `show`, `encode`, `decode`, `quote`, `pay`, `invite`, `demo`.
 
 ## What this prototype does NOT do yet
 
 - Execute real Lightning, on-chain, or Ark payments.
+- Enable mainnet Ark execution.
 - Verify email or domain ownership during registration.
 - Persist profiles to a decentralized registry (BIP-353, Nostr, DNS).
 - Support key rotation or profile revocation.
@@ -312,6 +314,7 @@ Test coverage includes:
 - Router: Lightning for small amounts
 - Router: On-chain for low fees
 - Router: Ark fallback for high fees
+- Ark route planning and testnet-gated intent safety
 - Router: Error when no methods available
 - Registry persistence across opens
 

--- a/crates/satspath-cli/src/commands/ark.rs
+++ b/crates/satspath-cli/src/commands/ark.rs
@@ -1,0 +1,307 @@
+use anyhow::Result;
+use satspath_core::{
+    crypto::verify_signed_profile,
+    privacy::{mask_address, mask_pubkey},
+    resolver::ProfileResolver,
+    validate_ark_receive_pointer, verify_ark_ownership_proof, ArkIntentStatus, ArkPaymentIntent,
+    ArkReceivePointer, ArkRouteKind, ClientValidationReport, PaymentMethod,
+};
+use satspath_router::{plan_ark_route, SenderCapabilities};
+use satspath_swaps::{ensure_claim_refund_builders_available, SwapKind};
+
+use super::get_resolver;
+
+const EXEC_CONFIRMATION: &str = "execute testnet ark intent";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArkSwapSide {
+    Ark,
+    Lightning,
+    Onchain,
+}
+
+pub async fn cmd_ark_receive(alias: &str, testnet: bool, execute_testnet: bool) -> Result<()> {
+    ensure_testnet(testnet)?;
+    if execute_testnet {
+        anyhow::bail!("Ark receive execution requires --confirm '{EXEC_CONFIRMATION}' in a future implementation. Preview only.");
+    }
+    let signed = get_resolver()?.resolve_alias(alias).await?;
+    let pointer = first_ark_pointer(&signed.profile.methods)?;
+    let report = build_validation_report(alias, &signed, &pointer)?;
+    print_validation_report(&report);
+    print_intent(&ArkPaymentIntent {
+        route_kind: ArkRouteKind::ArkToArk,
+        amount_sats: 0,
+        receiver_pointer: pointer,
+        status: ArkIntentStatus::PreviewOnly,
+        created_at: chrono::Utc::now().timestamp(),
+        expires_at: chrono::Utc::now().timestamp() + 900,
+    });
+    Ok(())
+}
+
+pub async fn cmd_ark_send(
+    alias: &str,
+    amount_sats: u64,
+    testnet: bool,
+    execute_testnet: bool,
+    confirm: Option<&str>,
+) -> Result<()> {
+    ensure_testnet(testnet)?;
+    let signed = get_resolver()?.resolve_alias(alias).await?;
+    let pointer = first_ark_pointer(&signed.profile.methods)?;
+    let report = build_validation_report(alias, &signed, &pointer)?;
+    let plan = plan_ark_route(
+        &SenderCapabilities {
+            ark_server: Some(pointer.server.clone()),
+            ..SenderCapabilities::default()
+        },
+        &signed,
+    )
+    .ok_or_else(|| anyhow::anyhow!("unsupported Ark route; failed closed"))?;
+
+    println!("Ark route preview");
+    println!("Route: {:?}", plan.kind);
+    println!("Server: {}", mask_address(&pointer.server));
+    println!("Receiver pubkey: {}", mask_pubkey(&pointer.receiver_pubkey));
+    println!("Amount: {} sats", amount_sats);
+    println!("Status: preview_only");
+    println!("No funds moved.");
+    print_validation_report(&report);
+
+    if execute_testnet {
+        ensure_exact_confirmation(confirm)?;
+        ensure_execution_allowed(&report)?;
+        println!("Execution: blocked");
+        anyhow::bail!("Ark method not implemented by bridge");
+    }
+    Ok(())
+}
+
+pub async fn cmd_ark_swap(
+    alias: &str,
+    amount_sats: u64,
+    from: ArkSwapSide,
+    to: ArkSwapSide,
+    testnet: bool,
+    execute_testnet: bool,
+    confirm: Option<&str>,
+) -> Result<()> {
+    ensure_testnet(testnet)?;
+    let signed = get_resolver()?.resolve_alias(alias).await?;
+    let pointer = first_ark_pointer(&signed.profile.methods).ok();
+    let route_kind = route_kind_from_sides(from, to)?;
+    let requires_builder = match route_kind {
+        ArkRouteKind::ArkToLightning => Some(SwapKind::Submarine),
+        ArkRouteKind::LightningToArk => Some(SwapKind::Reverse),
+        ArkRouteKind::ArkToOnchain | ArkRouteKind::OnchainToArk => Some(SwapKind::Chain),
+        ArkRouteKind::ArkToArk => None,
+    };
+
+    println!("Ark swap intent preview");
+    println!("Route: {:?}", route_kind);
+    println!("Amount: {} sats", amount_sats);
+    println!("Experimental: yes");
+    println!("Testnet only: yes");
+    if let Some(pointer) = &pointer {
+        println!("Receiver Ark server: {}", mask_address(&pointer.server));
+        println!("Receiver pubkey: {}", mask_pubkey(&pointer.receiver_pubkey));
+    }
+    println!("No funds moved.");
+
+    if execute_testnet {
+        ensure_exact_confirmation(confirm)?;
+        if let Some(kind) = requires_builder {
+            ensure_claim_refund_builders_available(kind).map_err(|e| anyhow::anyhow!("{}", e))?;
+        }
+        anyhow::bail!("Ark swap execution blocked: bridge/onboard/offboard path not implemented");
+    }
+
+    Ok(())
+}
+
+fn ensure_testnet(testnet: bool) -> Result<()> {
+    if !testnet {
+        anyhow::bail!(
+            "Ark commands are testnet-gated. Re-run with --testnet. Mainnet execution is disabled."
+        );
+    }
+    Ok(())
+}
+
+fn ensure_exact_confirmation(confirm: Option<&str>) -> Result<()> {
+    if confirm != Some(EXEC_CONFIRMATION) {
+        anyhow::bail!("testnet execution requires --confirm '{EXEC_CONFIRMATION}'");
+    }
+    Ok(())
+}
+
+fn ensure_execution_allowed(report: &ClientValidationReport) -> Result<()> {
+    if report.safe_for_testnet_execution {
+        Ok(())
+    } else {
+        anyhow::bail!("testnet execution blocked: {}", report.errors.join("; "))
+    }
+}
+
+fn first_ark_pointer(methods: &[PaymentMethod]) -> Result<ArkReceivePointer> {
+    methods
+        .iter()
+        .find_map(|method| match method {
+            PaymentMethod::Ark {
+                server,
+                pubkey,
+                vtxo_pointer,
+                proof,
+                expires_at,
+                ..
+            } => Some(ArkReceivePointer {
+                server: server.clone(),
+                receiver_pubkey: pubkey.clone(),
+                vtxo_pointer: vtxo_pointer.clone(),
+                proof: proof.clone(),
+                expires_at: *expires_at,
+            }),
+            _ => None,
+        })
+        .ok_or_else(|| anyhow::anyhow!("profile has no Ark receive pointer"))
+}
+
+fn build_validation_report(
+    alias: &str,
+    signed: &satspath_core::SignedPaymentProfile,
+    pointer: &ArkReceivePointer,
+) -> Result<ClientValidationReport> {
+    let now = chrono::Utc::now().timestamp();
+    let mut report = ClientValidationReport {
+        profile_signature_valid: verify_signed_profile(signed)?,
+        profile_fresh: signed.profile.expires_at.map(|ts| ts > now).unwrap_or(true),
+        ..ClientValidationReport::default()
+    };
+
+    match validate_ark_receive_pointer(pointer, now) {
+        Ok(()) => report.ark_pointer_valid = true,
+        Err(e) => report.errors.push(e.to_string()),
+    }
+
+    match verify_ark_ownership_proof(alias, pointer, now) {
+        Ok(true) => report.ark_ownership_verified = true,
+        Ok(false) => report
+            .warnings
+            .push("Ark ownership proof not provided; preview only.".into()),
+        Err(e) => report.errors.push(e.to_string()),
+    }
+
+    report.method_verified = report.ark_ownership_verified;
+    if !report.profile_signature_valid {
+        report.errors.push("profile signature invalid".into());
+    }
+    if !report.profile_fresh {
+        report.errors.push("profile expired".into());
+    }
+    report.safe_for_preview =
+        report.profile_signature_valid && report.profile_fresh && report.ark_pointer_valid;
+    report.safe_for_testnet_execution = report.safe_for_preview && report.ark_ownership_verified;
+    Ok(report)
+}
+
+fn print_validation_report(report: &ClientValidationReport) {
+    println!(
+        "Profile signature: {}",
+        valid_word(report.profile_signature_valid)
+    );
+    println!("Profile freshness: {}", valid_word(report.profile_fresh));
+    println!("Ark pointer: {}", valid_word(report.ark_pointer_valid));
+    println!(
+        "Ark ownership: {}",
+        if report.ark_ownership_verified {
+            "verified"
+        } else {
+            "unverified"
+        }
+    );
+    println!(
+        "Execution: {}",
+        if report.safe_for_testnet_execution {
+            "testnet allowed"
+        } else {
+            "preview only / blocked"
+        }
+    );
+    for warning in &report.warnings {
+        println!("Warning: {warning}");
+    }
+    for error in &report.errors {
+        println!("Error: {error}");
+    }
+}
+
+fn print_intent(intent: &ArkPaymentIntent) {
+    println!("Ark route preview");
+    println!("Route: {:?}", intent.route_kind);
+    println!("Server: {}", mask_address(&intent.receiver_pointer.server));
+    println!(
+        "Receiver pubkey: {}",
+        mask_pubkey(&intent.receiver_pointer.receiver_pubkey)
+    );
+    println!("Status: {:?}", intent.status);
+    println!("No funds moved.");
+}
+
+fn valid_word(value: bool) -> &'static str {
+    if value {
+        "valid"
+    } else {
+        "invalid"
+    }
+}
+
+fn route_kind_from_sides(from: ArkSwapSide, to: ArkSwapSide) -> Result<ArkRouteKind> {
+    match (from, to) {
+        (ArkSwapSide::Ark, ArkSwapSide::Lightning) => Ok(ArkRouteKind::ArkToLightning),
+        (ArkSwapSide::Lightning, ArkSwapSide::Ark) => Ok(ArkRouteKind::LightningToArk),
+        (ArkSwapSide::Ark, ArkSwapSide::Onchain) => Ok(ArkRouteKind::ArkToOnchain),
+        (ArkSwapSide::Onchain, ArkSwapSide::Ark) => Ok(ArkRouteKind::OnchainToArk),
+        (ArkSwapSide::Ark, ArkSwapSide::Ark) => Ok(ArkRouteKind::ArkToArk),
+        _ => anyhow::bail!("unsupported Ark swap route; failed closed"),
+    }
+}
+
+impl std::str::FromStr for ArkSwapSide {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "ark" => Ok(Self::Ark),
+            "lightning" => Ok(Self::Lightning),
+            "onchain" => Ok(Self::Onchain),
+            _ => anyhow::bail!("expected one of: ark, lightning, onchain"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_testnet_means_fail() {
+        assert!(ensure_testnet(false).is_err());
+    }
+
+    #[test]
+    fn exact_confirmation_required() {
+        assert!(ensure_exact_confirmation(None).is_err());
+        assert!(ensure_exact_confirmation(Some("wrong")).is_err());
+        assert!(ensure_exact_confirmation(Some(EXEC_CONFIRMATION)).is_ok());
+    }
+
+    #[test]
+    fn swap_side_routes() {
+        assert_eq!(
+            route_kind_from_sides(ArkSwapSide::Ark, ArkSwapSide::Lightning).unwrap(),
+            ArkRouteKind::ArkToLightning
+        );
+        assert!(route_kind_from_sides(ArkSwapSide::Lightning, ArkSwapSide::Onchain).is_err());
+    }
+}

--- a/crates/satspath-cli/src/commands/mod.rs
+++ b/crates/satspath-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod ark;
 mod demo;
 mod encode;
 mod init;
@@ -8,6 +9,7 @@ mod quote;
 mod register;
 mod show;
 
+pub use ark::{cmd_ark_receive, cmd_ark_send, cmd_ark_swap, ArkSwapSide};
 pub use demo::cmd_demo;
 pub use encode::{cmd_decode, cmd_encode};
 pub use init::cmd_init;

--- a/crates/satspath-cli/src/commands/register.rs
+++ b/crates/satspath-cli/src/commands/register.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use satspath_core::{
     crypto::{fingerprint_pubkey, generate_identity_keypair, sign_profile},
     privacy::{canonical_identifier, mask_identifier, mask_pubkey},
+    validate_ark_server_url,
     validation::{
         validate_bitcoin_address, validate_compressed_pubkey, validate_lightning_address,
     },
@@ -56,12 +57,15 @@ pub fn cmd_register(
 
     match (ark_server, ark_pubkey) {
         (Some(server), Some(pubkey)) => {
+            validate_ark_server_url(server).map_err(|e| anyhow::anyhow!("{}", e))?;
             validate_compressed_pubkey(pubkey).map_err(|e| anyhow::anyhow!("{}", e))?;
             methods.push(PaymentMethod::Ark {
                 label: "Ark".into(),
                 server: server.to_string(),
                 pubkey: pubkey.to_string(),
                 vtxo_pointer: None,
+                proof: None,
+                expires_at: None,
             });
         }
         (None, None) => {}

--- a/crates/satspath-cli/src/commands/show.rs
+++ b/crates/satspath-cli/src/commands/show.rs
@@ -81,12 +81,25 @@ pub async fn cmd_show(alias: &str) -> Result<()> {
                 server,
                 pubkey,
                 vtxo_pointer,
+                proof,
+                expires_at,
             } => {
                 println!("  - {} [Ark]", label);
                 println!("      Server: {}", mask_address(server));
                 println!("      Pubkey: {}", mask_pubkey(pubkey));
                 if vtxo_pointer.is_some() {
                     println!("      VTXO pointer: present");
+                }
+                println!(
+                    "      Ownership proof: {}",
+                    if proof.is_some() {
+                        "claimed"
+                    } else {
+                        "not provided"
+                    }
+                );
+                if let Some(expires_at) = expires_at {
+                    println!("      Expires at: {}", expires_at);
                 }
             }
         }

--- a/crates/satspath-cli/src/main.rs
+++ b/crates/satspath-cli/src/main.rs
@@ -1,7 +1,7 @@
 mod commands;
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(
@@ -75,8 +75,62 @@ enum Command {
     /// Generate an invite for an unregistered alias
     Invite { alias: String, amount_sats: u64 },
 
+    /// Ark direct receive/send and swap intents. Testnet-gated; mainnet execution disabled.
+    Ark {
+        #[command(subcommand)]
+        command: ArkCommand,
+    },
+
     /// Run the full SatsPath demo flow
     Demo,
+}
+
+#[derive(Subcommand)]
+enum ArkCommand {
+    /// Preview an Ark receive pointer for a registered alias.
+    Receive(ArkReceiveArgs),
+    /// Preview or testnet-execute a direct Ark send intent.
+    Send(ArkSendArgs),
+    /// Preview or testnet-execute an Ark swap intent.
+    Swap(ArkSwapArgs),
+}
+
+#[derive(Args)]
+struct ArkReceiveArgs {
+    #[arg(long)]
+    alias: String,
+    #[arg(long)]
+    testnet: bool,
+    #[arg(long)]
+    execute_testnet: bool,
+}
+
+#[derive(Args)]
+struct ArkSendArgs {
+    alias: String,
+    amount_sats: u64,
+    #[arg(long)]
+    testnet: bool,
+    #[arg(long)]
+    execute_testnet: bool,
+    #[arg(long)]
+    confirm: Option<String>,
+}
+
+#[derive(Args)]
+struct ArkSwapArgs {
+    alias: String,
+    amount_sats: u64,
+    #[arg(long)]
+    from: commands::ArkSwapSide,
+    #[arg(long)]
+    to: commands::ArkSwapSide,
+    #[arg(long)]
+    testnet: bool,
+    #[arg(long)]
+    execute_testnet: bool,
+    #[arg(long)]
+    confirm: Option<String>,
 }
 
 #[tokio::main]
@@ -127,6 +181,33 @@ async fn main() -> Result<()> {
             .await?
         }
         Command::Invite { alias, amount_sats } => commands::cmd_invite(&alias, amount_sats)?,
+        Command::Ark { command } => match command {
+            ArkCommand::Receive(args) => {
+                commands::cmd_ark_receive(&args.alias, args.testnet, args.execute_testnet).await?
+            }
+            ArkCommand::Send(args) => {
+                commands::cmd_ark_send(
+                    &args.alias,
+                    args.amount_sats,
+                    args.testnet,
+                    args.execute_testnet,
+                    args.confirm.as_deref(),
+                )
+                .await?
+            }
+            ArkCommand::Swap(args) => {
+                commands::cmd_ark_swap(
+                    &args.alias,
+                    args.amount_sats,
+                    args.from,
+                    args.to,
+                    args.testnet,
+                    args.execute_testnet,
+                    args.confirm.as_deref(),
+                )
+                .await?
+            }
+        },
         Command::Demo => commands::cmd_demo().await?,
     }
 

--- a/crates/satspath-core/src/ark.rs
+++ b/crates/satspath-core/src/ark.rs
@@ -1,0 +1,250 @@
+use secp256k1::{ecdsa::Signature, Message, PublicKey, Secp256k1};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use crate::errors::{Result, SatsPathError};
+use crate::validation::{assert_no_private_material, validate_compressed_pubkey};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ArkRouteKind {
+    ArkToArk,
+    ArkToLightning,
+    LightningToArk,
+    ArkToOnchain,
+    OnchainToArk,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArkReceivePointer {
+    pub server: String,
+    pub receiver_pubkey: String,
+    pub vtxo_pointer: Option<String>,
+    pub proof: Option<ArkOwnershipProof>,
+    pub expires_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArkOwnershipProof {
+    pub message: String,
+    pub signature: String,
+    pub pubkey: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ArkIntentStatus {
+    PreviewOnly,
+    TestnetReady,
+    TestnetExecutionBlocked,
+    ExecutedTestnet,
+    Expired,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArkPaymentIntent {
+    pub route_kind: ArkRouteKind,
+    pub amount_sats: u64,
+    pub receiver_pointer: ArkReceivePointer,
+    pub status: ArkIntentStatus,
+    pub created_at: i64,
+    pub expires_at: i64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClientValidationReport {
+    pub profile_signature_valid: bool,
+    pub profile_fresh: bool,
+    pub ark_pointer_valid: bool,
+    pub ark_ownership_verified: bool,
+    pub method_verified: bool,
+    pub safe_for_preview: bool,
+    pub safe_for_testnet_execution: bool,
+    pub warnings: Vec<String>,
+    pub errors: Vec<String>,
+}
+
+pub fn ark_ownership_challenge(
+    alias: &str,
+    ark_server: &str,
+    receiver_pubkey: &str,
+    nonce: &str,
+) -> String {
+    format!("satspath-proof:{alias}:ark:{ark_server}:{receiver_pubkey}:{nonce}")
+}
+
+pub fn validate_ark_server_url(server: &str) -> Result<()> {
+    assert_no_private_material(server)?;
+    let parsed =
+        Url::parse(server).map_err(|e| SatsPathError::InvalidPaymentPointer(e.to_string()))?;
+    if parsed.scheme() != "https" {
+        return Err(SatsPathError::InvalidPaymentPointer(
+            "Ark server URL must use https".into(),
+        ));
+    }
+    if parsed.host_str().is_none() {
+        return Err(SatsPathError::InvalidPaymentPointer(
+            "Ark server URL must include a host".into(),
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_ark_receive_pointer(pointer: &ArkReceivePointer, now: i64) -> Result<()> {
+    validate_ark_server_url(&pointer.server)?;
+    validate_compressed_pubkey(&pointer.receiver_pubkey)?;
+    if let Some(vtxo) = &pointer.vtxo_pointer {
+        assert_no_private_material(vtxo)?;
+    }
+    if let Some(expires_at) = pointer.expires_at {
+        if expires_at <= now {
+            return Err(SatsPathError::InvalidPaymentPointer(
+                "Ark receive pointer expired".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn verify_ark_ownership_proof(
+    alias: &str,
+    pointer: &ArkReceivePointer,
+    now: i64,
+) -> Result<bool> {
+    validate_ark_receive_pointer(pointer, now)?;
+    let Some(proof) = &pointer.proof else {
+        return Ok(false);
+    };
+    validate_compressed_pubkey(&proof.pubkey)?;
+    if proof.pubkey != pointer.receiver_pubkey {
+        return Err(SatsPathError::InvalidSignature);
+    }
+    if let Some(expires_at) = pointer.expires_at {
+        if expires_at <= now {
+            return Err(SatsPathError::InvalidPaymentPointer(
+                "Ark ownership proof expired".into(),
+            ));
+        }
+    }
+
+    let expected_prefix =
+        ark_ownership_challenge(alias, &pointer.server, &pointer.receiver_pubkey, "");
+    if !proof.message.starts_with(&expected_prefix) || proof.message == expected_prefix {
+        return Err(SatsPathError::InvalidSignature);
+    }
+
+    let pubkey_bytes =
+        hex::decode(&proof.pubkey).map_err(|e| SatsPathError::InvalidPublicKey(e.to_string()))?;
+    let pubkey = PublicKey::from_slice(&pubkey_bytes)
+        .map_err(|e| SatsPathError::InvalidPublicKey(e.to_string()))?;
+    let sig_bytes =
+        hex::decode(&proof.signature).map_err(|e| SatsPathError::CryptoError(e.to_string()))?;
+    let sig =
+        Signature::from_der(&sig_bytes).map_err(|e| SatsPathError::CryptoError(e.to_string()))?;
+    let digest = Sha256::digest(proof.message.as_bytes());
+    let message = Message::from_digest(digest.into());
+    Ok(Secp256k1::verification_only()
+        .verify_ecdsa(&message, &sig, &pubkey)
+        .is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secp256k1::{Secp256k1, SecretKey};
+
+    fn signed_pointer(
+        alias: &str,
+        server: &str,
+        nonce: &str,
+        expires_at: Option<i64>,
+    ) -> ArkReceivePointer {
+        let secp = Secp256k1::new();
+        let secret = SecretKey::from_slice(&[1u8; 32]).unwrap();
+        let pubkey = secret.public_key(&secp);
+        let pubkey_hex = hex::encode(pubkey.serialize());
+        let message = ark_ownership_challenge(alias, server, &pubkey_hex, nonce);
+        let digest = Sha256::digest(message.as_bytes());
+        let sig = secp.sign_ecdsa(&Message::from_digest(digest.into()), &secret);
+        ArkReceivePointer {
+            server: server.into(),
+            receiver_pubkey: pubkey_hex.clone(),
+            vtxo_pointer: None,
+            proof: Some(ArkOwnershipProof {
+                message,
+                signature: hex::encode(sig.serialize_der()),
+                pubkey: pubkey_hex,
+            }),
+            expires_at,
+        }
+    }
+
+    #[test]
+    fn valid_proof_accepted() {
+        let pointer = signed_pointer(
+            "alice@example.com",
+            "https://ark.example.com",
+            "n1",
+            Some(2_000),
+        );
+        assert!(verify_ark_ownership_proof("alice@example.com", &pointer, 1_000).unwrap());
+    }
+
+    #[test]
+    fn pubkey_incorrect_rejected() {
+        let mut pointer = signed_pointer(
+            "alice@example.com",
+            "https://ark.example.com",
+            "n1",
+            Some(2_000),
+        );
+        pointer.receiver_pubkey =
+            "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798".into();
+        assert!(verify_ark_ownership_proof("alice@example.com", &pointer, 1_000).is_err());
+    }
+
+    #[test]
+    fn server_incorrect_rejected() {
+        let mut pointer = signed_pointer(
+            "alice@example.com",
+            "https://ark.example.com",
+            "n1",
+            Some(2_000),
+        );
+        pointer.server = "https://evil.example.com".into();
+        assert!(verify_ark_ownership_proof("alice@example.com", &pointer, 1_000).is_err());
+    }
+
+    #[test]
+    fn alias_incorrect_rejected() {
+        let pointer = signed_pointer(
+            "alice@example.com",
+            "https://ark.example.com",
+            "n1",
+            Some(2_000),
+        );
+        assert!(verify_ark_ownership_proof("bob@example.com", &pointer, 1_000).is_err());
+    }
+
+    #[test]
+    fn malformed_signature_rejected() {
+        let mut pointer = signed_pointer(
+            "alice@example.com",
+            "https://ark.example.com",
+            "n1",
+            Some(2_000),
+        );
+        pointer.proof.as_mut().unwrap().signature = "not-hex".into();
+        assert!(verify_ark_ownership_proof("alice@example.com", &pointer, 1_000).is_err());
+    }
+
+    #[test]
+    fn proof_expired_rejected() {
+        let pointer = signed_pointer(
+            "alice@example.com",
+            "https://ark.example.com",
+            "n1",
+            Some(999),
+        );
+        assert!(verify_ark_ownership_proof("alice@example.com", &pointer, 1_000).is_err());
+    }
+}

--- a/crates/satspath-core/src/codec.rs
+++ b/crates/satspath-core/src/codec.rs
@@ -33,16 +33,14 @@ pub fn encode_payment_request(
 ///   - `satspath:<alias>`              — simple form
 ///   - `satspath:v1:<base64url_json>`  — encoded form
 pub fn decode_payment_request(uri: &str) -> Result<PaymentRequest> {
-    if uri.starts_with(V1_PREFIX) {
-        let encoded = &uri[V1_PREFIX.len()..];
+    if let Some(encoded) = uri.strip_prefix(V1_PREFIX) {
         let bytes = URL_SAFE_NO_PAD
             .decode(encoded)
             .map_err(|e| SatsPathError::InvalidPaymentUri(e.to_string()))?;
         let req: PaymentRequest = serde_json::from_slice(&bytes)
             .map_err(|e| SatsPathError::InvalidPaymentUri(e.to_string()))?;
         Ok(req)
-    } else if uri.starts_with(SATSPATH_SCHEME) {
-        let alias = &uri[SATSPATH_SCHEME.len()..];
+    } else if let Some(alias) = uri.strip_prefix(SATSPATH_SCHEME) {
         if alias.is_empty() {
             return Err(SatsPathError::InvalidPaymentUri("alias is empty".into()));
         }

--- a/crates/satspath-core/src/lib.rs
+++ b/crates/satspath-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod ark;
 pub mod codec;
 pub mod crypto;
 pub mod errors;
@@ -11,6 +12,11 @@ pub mod resolver;
 pub mod resolvers;
 pub mod validation;
 
+pub use ark::{
+    ark_ownership_challenge, validate_ark_receive_pointer, validate_ark_server_url,
+    verify_ark_ownership_proof, ArkIntentStatus, ArkOwnershipProof, ArkPaymentIntent,
+    ArkReceivePointer, ArkRouteKind, ClientValidationReport,
+};
 pub use errors::{Result, SatsPathError};
 pub use peer_registry::{
     canonicalize_identifier, display_hint, hash_identifier, LocalPeerRegistry, MockPeerRegistry,

--- a/crates/satspath-core/src/ownership.rs
+++ b/crates/satspath-core/src/ownership.rs
@@ -626,7 +626,7 @@ mod tests {
     use crate::crypto::{generate_identity_keypair, sign_message};
     use crate::profile::PaymentMethod;
     use bitcoin::{Address, CompressedPublicKey, Network, XOnlyPublicKey};
-    use secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use secp256k1::{Secp256k1, SecretKey};
 
     const NOW: i64 = 1_700_000_000;
 
@@ -672,6 +672,8 @@ mod tests {
             server: "https://ark.example.com".into(),
             pubkey: pubkey_hex.into(),
             vtxo_pointer: None,
+            proof: None,
+            expires_at: None,
         }
     }
 
@@ -772,10 +774,12 @@ mod tests {
         )
         .unwrap();
 
-        if let VerificationStatus::Verified { proof, .. } = &mut verification.status {
-            if let OwnershipProof::MessageSignature { message, .. } = proof {
-                *message = "SatsPath Ownership Proof v1\nidentity=evil".into();
-            }
+        if let VerificationStatus::Verified {
+            proof: OwnershipProof::MessageSignature { message, .. },
+            ..
+        } = &mut verification.status
+        {
+            *message = "SatsPath Ownership Proof v1\nidentity=evil".into();
         }
         assert!(verify_method_verification(
             &method,

--- a/crates/satspath-core/src/profile.rs
+++ b/crates/satspath-core/src/profile.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::ark::ArkOwnershipProof;
 use crate::pointer::BitcoinNetwork;
 
 /// A single payment method supported by the profile owner.
@@ -36,6 +37,10 @@ pub enum PaymentMethod {
         pubkey: String,
         #[serde(default)]
         vtxo_pointer: Option<String>,
+        #[serde(default)]
+        proof: Option<ArkOwnershipProof>,
+        #[serde(default)]
+        expires_at: Option<i64>,
     },
 }
 

--- a/crates/satspath-core/src/registry.rs
+++ b/crates/satspath-core/src/registry.rs
@@ -73,7 +73,7 @@ impl Registry {
             .profiles
             .get(&key)
             .or_else(|| self.data.profiles.get(&canonical))
-            .ok_or_else(|| SatsPathError::AliasNotFound(canonical))
+            .ok_or(SatsPathError::AliasNotFound(canonical))
     }
 
     /// Check whether an alias is already registered.

--- a/crates/satspath-core/src/resolver.rs
+++ b/crates/satspath-core/src/resolver.rs
@@ -35,6 +35,12 @@ impl ChainResolver {
     }
 }
 
+impl Default for ChainResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[async_trait]
 impl ProfileResolver for ChainResolver {
     async fn resolve_alias(&self, alias: &str) -> Result<SignedPaymentProfile> {

--- a/crates/satspath-core/src/resolvers/bip353.rs
+++ b/crates/satspath-core/src/resolvers/bip353.rs
@@ -19,6 +19,12 @@ impl Bip353Resolver {
     }
 }
 
+impl Default for Bip353Resolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[async_trait]
 impl ProfileResolver for Bip353Resolver {
     async fn resolve_alias(&self, alias: &str) -> Result<SignedPaymentProfile> {

--- a/crates/satspath-core/src/resolvers/http.rs
+++ b/crates/satspath-core/src/resolvers/http.rs
@@ -24,6 +24,12 @@ impl HttpResolver {
     }
 }
 
+impl Default for HttpResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[async_trait]
 impl ProfileResolver for HttpResolver {
     async fn resolve_alias(&self, alias: &str) -> Result<SignedPaymentProfile> {

--- a/crates/satspath-core/src/validation.rs
+++ b/crates/satspath-core/src/validation.rs
@@ -2,6 +2,7 @@ use bitcoin::{Address, Network};
 use secp256k1::PublicKey;
 use std::str::FromStr;
 
+use crate::ark::{validate_ark_receive_pointer, verify_ark_ownership_proof, ArkReceivePointer};
 use crate::errors::{Result, SatsPathError};
 use crate::pointer::BitcoinNetwork;
 use crate::profile::{ClaimPolicy, PaymentMethod, PaymentProfile};
@@ -200,16 +201,21 @@ pub fn validate_public_profile(profile: &PaymentProfile) -> Result<()> {
                 server,
                 pubkey,
                 vtxo_pointer,
+                proof,
+                expires_at,
                 ..
             } => {
-                if server.trim().is_empty() {
-                    return Err(SatsPathError::InvalidPaymentPointer(
-                        "Ark server is required".into(),
-                    ));
-                }
-                validate_compressed_pubkey(pubkey)?;
-                if let Some(vtxo) = vtxo_pointer {
-                    assert_no_private_material(vtxo)?;
+                let pointer = ArkReceivePointer {
+                    server: server.clone(),
+                    receiver_pubkey: pubkey.clone(),
+                    vtxo_pointer: vtxo_pointer.clone(),
+                    proof: proof.clone(),
+                    expires_at: *expires_at,
+                };
+                let now = chrono::Utc::now().timestamp();
+                validate_ark_receive_pointer(&pointer, now)?;
+                if proof.is_some() && !verify_ark_ownership_proof(&profile.alias, &pointer, now)? {
+                    return Err(SatsPathError::InvalidSignature);
                 }
             }
         }

--- a/crates/satspath-router/src/ark_routes.rs
+++ b/crates/satspath-router/src/ark_routes.rs
@@ -132,6 +132,7 @@ mod tests {
                 methods,
                 updated_at: 1,
                 expires_at: None,
+                method_verifications: Vec::new(),
             },
             signature: "sig".into(),
         }

--- a/crates/satspath-router/src/ark_routes.rs
+++ b/crates/satspath-router/src/ark_routes.rs
@@ -1,0 +1,247 @@
+use satspath_core::{ArkRouteKind, PaymentMethod, SignedPaymentProfile};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArkRoutePlan {
+    pub kind: ArkRouteKind,
+    pub requires_swap: bool,
+    pub requires_boltz: bool,
+    pub requires_ark_bridge: bool,
+    pub testnet_only: bool,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SenderCapabilities {
+    pub ark_server: Option<String>,
+    pub has_lightning: bool,
+    pub has_onchain: bool,
+}
+
+pub fn plan_ark_route(
+    sender: &SenderCapabilities,
+    receiver: &SignedPaymentProfile,
+) -> Option<ArkRoutePlan> {
+    let receiver_ark = first_ark(receiver);
+    let receiver_lightning = has_lightning(receiver);
+    let receiver_onchain = has_onchain(receiver);
+
+    if let (Some(sender_server), Some((receiver_server, _receiver_pubkey))) =
+        (&sender.ark_server, receiver_ark)
+    {
+        if sender_server == receiver_server {
+            return Some(ArkRoutePlan {
+                kind: ArkRouteKind::ArkToArk,
+                requires_swap: false,
+                requires_boltz: false,
+                requires_ark_bridge: true,
+                testnet_only: true,
+                reason: "Sender and receiver use the same Ark server; direct VTXO transfer intent."
+                    .into(),
+            });
+        }
+    }
+
+    if sender.ark_server.is_some() && receiver_lightning {
+        return Some(ArkRoutePlan {
+            kind: ArkRouteKind::ArkToLightning,
+            requires_swap: true,
+            requires_boltz: true,
+            requires_ark_bridge: true,
+            testnet_only: true,
+            reason: "Sender has Ark and receiver has Lightning; requires swap/offboard path."
+                .into(),
+        });
+    }
+
+    if sender.has_lightning && receiver_ark.is_some() {
+        return Some(ArkRoutePlan {
+            kind: ArkRouteKind::LightningToArk,
+            requires_swap: true,
+            requires_boltz: true,
+            requires_ark_bridge: true,
+            testnet_only: true,
+            reason: "Sender has Lightning and receiver has Ark; requires onboard/reverse path."
+                .into(),
+        });
+    }
+
+    if sender.ark_server.is_some() && receiver_onchain {
+        return Some(ArkRoutePlan {
+            kind: ArkRouteKind::ArkToOnchain,
+            requires_swap: true,
+            requires_boltz: true,
+            requires_ark_bridge: true,
+            testnet_only: true,
+            reason: "Sender has Ark and receiver has on-chain; requires offboard path.".into(),
+        });
+    }
+
+    if sender.has_onchain && receiver_ark.is_some() {
+        return Some(ArkRoutePlan {
+            kind: ArkRouteKind::OnchainToArk,
+            requires_swap: true,
+            requires_boltz: true,
+            requires_ark_bridge: true,
+            testnet_only: true,
+            reason: "Sender has on-chain and receiver has Ark; requires onboard path.".into(),
+        });
+    }
+
+    None
+}
+
+fn first_ark(profile: &SignedPaymentProfile) -> Option<(&str, &str)> {
+    profile
+        .profile
+        .methods
+        .iter()
+        .find_map(|method| match method {
+            PaymentMethod::Ark { server, pubkey, .. } => Some((server.as_str(), pubkey.as_str())),
+            _ => None,
+        })
+}
+
+fn has_lightning(profile: &SignedPaymentProfile) -> bool {
+    profile
+        .profile
+        .methods
+        .iter()
+        .any(|method| matches!(method, PaymentMethod::Lightning { .. }))
+}
+
+fn has_onchain(profile: &SignedPaymentProfile) -> bool {
+    profile
+        .profile
+        .methods
+        .iter()
+        .any(|method| matches!(method, PaymentMethod::Onchain { .. }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use satspath_core::{PaymentProfile, SignedPaymentProfile};
+
+    const PUBKEY: &str = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+    fn signed(methods: Vec<PaymentMethod>) -> SignedPaymentProfile {
+        SignedPaymentProfile {
+            profile: PaymentProfile {
+                alias: "alice@example.com".into(),
+                identity_pubkey: PUBKEY.into(),
+                methods,
+                updated_at: 1,
+                expires_at: None,
+            },
+            signature: "sig".into(),
+        }
+    }
+
+    fn ark(server: &str) -> PaymentMethod {
+        PaymentMethod::Ark {
+            label: "Ark".into(),
+            server: server.into(),
+            pubkey: PUBKEY.into(),
+            vtxo_pointer: None,
+            proof: None,
+            expires_at: None,
+        }
+    }
+
+    fn lightning() -> PaymentMethod {
+        PaymentMethod::Lightning {
+            label: "LN".into(),
+            lightning_address: Some("alice@example.com".into()),
+            lnurl: None,
+            bolt12: None,
+            receiver_pubkey: None,
+        }
+    }
+
+    fn onchain() -> PaymentMethod {
+        PaymentMethod::Onchain {
+            label: "BTC".into(),
+            network: satspath_core::BitcoinNetwork::Mainnet,
+            address: "1BoatSLRHtKNngkdXEeobR76b53LETtpyT".into(),
+            pubkey_hint: None,
+            descriptor_hint: None,
+        }
+    }
+
+    #[test]
+    fn ark_to_ark_same_server() {
+        let plan = plan_ark_route(
+            &SenderCapabilities {
+                ark_server: Some("https://ark.example.com".into()),
+                ..SenderCapabilities::default()
+            },
+            &signed(vec![ark("https://ark.example.com")]),
+        )
+        .unwrap();
+        assert_eq!(plan.kind, ArkRouteKind::ArkToArk);
+        assert!(!plan.requires_swap);
+    }
+
+    #[test]
+    fn ark_to_lightning_requires_swap() {
+        let plan = plan_ark_route(
+            &SenderCapabilities {
+                ark_server: Some("https://ark.example.com".into()),
+                ..SenderCapabilities::default()
+            },
+            &signed(vec![lightning()]),
+        )
+        .unwrap();
+        assert_eq!(plan.kind, ArkRouteKind::ArkToLightning);
+        assert!(plan.requires_swap);
+    }
+
+    #[test]
+    fn lightning_to_ark_requires_onboard_or_reverse_path() {
+        let plan = plan_ark_route(
+            &SenderCapabilities {
+                has_lightning: true,
+                ..SenderCapabilities::default()
+            },
+            &signed(vec![ark("https://ark.example.com")]),
+        )
+        .unwrap();
+        assert_eq!(plan.kind, ArkRouteKind::LightningToArk);
+        assert!(plan.requires_boltz);
+    }
+
+    #[test]
+    fn ark_to_onchain_requires_offboard() {
+        let plan = plan_ark_route(
+            &SenderCapabilities {
+                ark_server: Some("https://ark.example.com".into()),
+                ..SenderCapabilities::default()
+            },
+            &signed(vec![onchain()]),
+        )
+        .unwrap();
+        assert_eq!(plan.kind, ArkRouteKind::ArkToOnchain);
+        assert!(plan.requires_ark_bridge);
+    }
+
+    #[test]
+    fn onchain_to_ark_requires_onboard() {
+        let plan = plan_ark_route(
+            &SenderCapabilities {
+                has_onchain: true,
+                ..SenderCapabilities::default()
+            },
+            &signed(vec![ark("https://ark.example.com")]),
+        )
+        .unwrap();
+        assert_eq!(plan.kind, ArkRouteKind::OnchainToArk);
+        assert!(plan.requires_swap);
+    }
+
+    #[test]
+    fn unsupported_route_fails_closed() {
+        assert!(
+            plan_ark_route(&SenderCapabilities::default(), &signed(vec![lightning()])).is_none()
+        );
+    }
+}

--- a/crates/satspath-router/src/lib.rs
+++ b/crates/satspath-router/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod ark;
+pub mod ark_routes;
 pub mod fees;
 pub mod lightning;
 pub mod onchain;
 pub mod router;
 pub mod scoring;
 
+pub use ark_routes::{plan_ark_route, ArkRoutePlan, SenderCapabilities};
 pub use lightning::{fetch_invoice, fetch_lnurl_metadata, LnurlPayMetadata};
 pub use router::{
     select_route, select_route_with_fees, FeeRateSnapshot, RouteQuote, RouteRequest, SwapDirective,

--- a/crates/satspath-router/src/lightning.rs
+++ b/crates/satspath-router/src/lightning.rs
@@ -169,14 +169,14 @@ pub fn parse_bolt11_amount_sats(invoice: &str) -> Option<u64> {
         Some('u') => amount_val.checked_mul(100),     // micro-BTC = 100 sats
         Some('n') => {
             // nano-BTC = 0.1 sats; must be divisible by 10 for whole sats
-            if amount_val % 10 != 0 {
+            if !amount_val.is_multiple_of(10) {
                 return None;
             }
             Some(amount_val / 10)
         }
         Some('p') => {
             // pico-BTC = 0.0001 sats; must be divisible by 10_000
-            if amount_val % 10_000 != 0 {
+            if !amount_val.is_multiple_of(10_000) {
                 return None;
             }
             Some(amount_val / 10_000)

--- a/crates/satspath-router/src/router.rs
+++ b/crates/satspath-router/src/router.rs
@@ -59,8 +59,8 @@ pub struct RouteQuote {
 ///
 /// Priority:
 ///   1. Lightning  — if amount < 100 000 sats and a Lightning method exists.
-///                   NOTE: Lightning is checked BEFORE on-chain fees.
-///                   The dust threshold must NOT block Lightning route selection.
+///      NOTE: Lightning is checked BEFORE on-chain fees.
+///      The dust threshold must NOT block Lightning route selection.
 ///   2. On-chain   — if fastestFee ≤ 20 sat/vB (next block, <10 min).
 ///   3. Ark        — fallback when on-chain fees are too high.
 ///   4. Error      — no suitable rail found.
@@ -356,9 +356,11 @@ mod tests {
             },
             PaymentMethod::Ark {
                 label: "Ark".into(),
-                server: "ark.example.com".into(),
-                pubkey: "aabbcc".into(),
+                server: "https://ark.example.com".into(),
+                pubkey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798".into(),
                 vtxo_pointer: None,
+                proof: None,
+                expires_at: None,
             },
         ]);
         let req = RouteRequest {

--- a/crates/satspath-router/src/router.rs
+++ b/crates/satspath-router/src/router.rs
@@ -427,5 +427,4 @@ mod tests {
             SatsPathError::NoRouteFound(_)
         ));
     }
-
 }

--- a/crates/satspath-router/src/scoring.rs
+++ b/crates/satspath-router/src/scoring.rs
@@ -1,5 +1,7 @@
 use satspath_core::{PaymentMethod, PaymentPointer, Result, SatsPathError, SignedPaymentProfile};
 
+use crate::ark_routes::SenderCapabilities;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PaymentRail {
     Lightning,
@@ -35,6 +37,7 @@ pub struct RoutePreferences {
     pub prefer_privacy: bool,
     pub allow_experimental_ark: bool,
     pub max_fee_sats: Option<u64>,
+    pub sender_capabilities: SenderCapabilities,
 }
 
 impl Default for RoutePreferences {
@@ -45,6 +48,7 @@ impl Default for RoutePreferences {
             prefer_privacy: false,
             allow_experimental_ark: false,
             max_fee_sats: None,
+            sender_capabilities: SenderCapabilities::default(),
         }
     }
 }
@@ -151,6 +155,8 @@ pub fn score_routes(
                 ..
             } => {
                 let available = preferences.allow_experimental_ark;
+                let plan =
+                    crate::ark_routes::plan_ark_route(&preferences.sender_capabilities, profile);
                 candidates.push(RouteCandidate {
                     rail: PaymentRail::Ark,
                     estimated_fee_sats: fee_snapshot.ark_fee_sats_estimate.or(Some(1)),
@@ -159,8 +165,11 @@ pub fn score_routes(
                     reliability_score: if available { 5 } else { 2 },
                     requires_user_action: true,
                     available,
-                    reason: if available {
-                        "Ark pointer available; experimental route allowed.".into()
+                    reason: if let Some(plan) = plan {
+                        format!("{} Ark routes remain testnet-gated.", plan.reason)
+                    } else if available {
+                        "Ark pointer available; no executable sender path declared; intent preview only."
+                            .into()
                     } else {
                         "Ark pointer available but experimental Ark is disabled.".into()
                     },
@@ -338,6 +347,8 @@ mod tests {
             server: "https://ark.example.com".into(),
             pubkey: valid_pubkey.into(),
             vtxo_pointer: None,
+            proof: None,
+            expires_at: None,
         }]);
         assert!(score_routes(
             1_000,

--- a/crates/satspath-swaps/src/ark_bridge.rs
+++ b/crates/satspath-swaps/src/ark_bridge.rs
@@ -19,7 +19,8 @@ struct RpcRequest<T> {
 
 #[derive(Deserialize, Debug)]
 struct RpcResponse<T> {
-    id: serde_json::Value,
+    #[serde(rename = "id")]
+    _id: serde_json::Value,
     result: Option<T>,
     error: Option<RpcError>,
 }
@@ -72,6 +73,81 @@ pub struct OnReceiveVtxoResult {
     pub success: bool,
     pub diagnostics: Vec<String>,
     pub error: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct GetReceivePubkeyResult {
+    pub pubkey: String,
+    pub server: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct SignArkChallengeParams {
+    pub alias: String,
+    pub server: String,
+    pub receiver_pubkey: String,
+    pub nonce: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct SignArkChallengeResult {
+    pub message: String,
+    pub signature: String,
+    pub pubkey: String,
+    pub expires_at: Option<i64>,
+}
+
+#[derive(Serialize)]
+pub struct CreateReceiveVtxoParams {
+    pub amount_sats: u64,
+    pub receiver_pubkey: String,
+    pub server: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct CreateReceiveVtxoResult {
+    pub request_id: String,
+    pub receiver_pubkey: String,
+    pub server: String,
+    pub expires_at: i64,
+}
+
+#[derive(Serialize)]
+pub struct SendVtxoParams {
+    pub amount_sats: u64,
+    pub receiver_pubkey: String,
+    pub server: String,
+    pub vtxo_pointer: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct SendVtxoResult {
+    pub intent_id: String,
+    pub txid: Option<String>,
+    pub status: String,
+}
+
+#[derive(Serialize)]
+pub struct ListVtxosParams {
+    pub server: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ListVtxosResult {
+    pub vtxos: Vec<serde_json::Value>,
+}
+
+#[derive(Serialize)]
+pub struct EstimateArkFeeParams {
+    pub route_kind: String,
+    pub amount_sats: u64,
+    pub server: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct EstimateArkFeeResult {
+    pub fee_sats: u64,
+    pub diagnostics: Vec<String>,
 }
 
 // ─── Bridge Client ────────────────────────────────────────────────────────────
@@ -141,17 +217,14 @@ impl ArkBridge {
             stdout.read_line(&mut line).map_err(SwapError::Io)?;
         }
 
-        let resp: RpcResponse<R> = serde_json::from_str(&line).map_err(|e| SwapError::Json(e))?;
+        let resp: RpcResponse<R> = serde_json::from_str(&line).map_err(SwapError::Json)?;
 
         if let Some(err) = resp.error {
-            return Err(SwapError::Key(format!(
-                "ARK bridge error ({}): {}",
-                err.code, err.message
-            )));
+            return Err(map_ark_bridge_error(err));
         }
 
         resp.result
-            .ok_or_else(|| SwapError::Key(format!("ARK bridge returned neither result nor error")))
+            .ok_or_else(|| SwapError::Key("ARK bridge returned neither result nor error".into()))
     }
 
     // ─── API Wrapper ──────────────────────────────────────────────────────────
@@ -175,6 +248,44 @@ impl ArkBridge {
 
     pub fn on_receive_vtxo(&self, params: OnReceiveVtxoParams) -> Result<OnReceiveVtxoResult> {
         self.call("onReceiveVtxo", params)
+    }
+
+    pub fn get_receive_pubkey(&self) -> Result<GetReceivePubkeyResult> {
+        self.call("getReceivePubkey", serde_json::json!({}))
+    }
+
+    pub fn sign_ownership_challenge(
+        &self,
+        params: SignArkChallengeParams,
+    ) -> Result<SignArkChallengeResult> {
+        self.call("signOwnershipChallenge", params)
+    }
+
+    pub fn create_receive_vtxo_request(
+        &self,
+        params: CreateReceiveVtxoParams,
+    ) -> Result<CreateReceiveVtxoResult> {
+        self.call("createReceiveVtxoRequest", params)
+    }
+
+    pub fn send_vtxo(&self, params: SendVtxoParams) -> Result<SendVtxoResult> {
+        self.call("sendVtxo", params)
+    }
+
+    pub fn list_vtxos(&self, params: ListVtxosParams) -> Result<ListVtxosResult> {
+        self.call("listVtxos", params)
+    }
+
+    pub fn estimate_ark_fee(&self, params: EstimateArkFeeParams) -> Result<EstimateArkFeeResult> {
+        self.call("estimateArkFee", params)
+    }
+}
+
+fn map_ark_bridge_error(err: RpcError) -> SwapError {
+    if err.code == -32601 || err.message.to_ascii_lowercase().contains("not implemented") {
+        SwapError::Key("Ark method not implemented by bridge".into())
+    } else {
+        SwapError::Key(format!("ARK bridge error ({}): {}", err.code, err.message))
     }
 }
 

--- a/crates/satspath-swaps/src/boltz_client.rs
+++ b/crates/satspath-swaps/src/boltz_client.rs
@@ -274,7 +274,7 @@ impl BoltzClient {
             });
         }
 
-        serde_json::from_str(&body).map_err(|e| SwapError::Json(serde_json::Error::from(e)))
+        serde_json::from_str(&body).map_err(SwapError::Json)
     }
 
     // ── GET /v2/swap/fees ─────────────────────────────────────────────────
@@ -439,7 +439,7 @@ impl BoltzClient {
         target: Option<&[SwapStatus]>,
         max_wait: Duration,
     ) -> Result<WsSwapUpdate> {
-        let ws_url = format!("{}", self.ws_url);
+        let ws_url = self.ws_url.to_string();
 
         let (mut ws, _) = connect_async(&ws_url)
             .await

--- a/crates/satspath-swaps/src/chain_swap.rs
+++ b/crates/satspath-swaps/src/chain_swap.rs
@@ -77,7 +77,7 @@ pub async fn create_chain_swap(
     // Generate preimage (the atomic secret for both HTLC legs)
     let mut preimage = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut preimage);
-    let preimage_hash: [u8; 32] = Sha256::digest(&preimage).into();
+    let preimage_hash: [u8; 32] = Sha256::digest(preimage).into();
 
     let secp = Secp256k1::new();
     let mut rng = rand::thread_rng();

--- a/crates/satspath-swaps/src/execution_gate.rs
+++ b/crates/satspath-swaps/src/execution_gate.rs
@@ -1,0 +1,30 @@
+use crate::errors::{Result, SwapError};
+use crate::types::SwapKind;
+
+pub fn claim_refund_builders_available(kind: SwapKind) -> bool {
+    match kind {
+        SwapKind::Submarine | SwapKind::Reverse | SwapKind::Chain => false,
+    }
+}
+
+pub fn ensure_claim_refund_builders_available(kind: SwapKind) -> Result<()> {
+    if claim_refund_builders_available(kind) {
+        Ok(())
+    } else {
+        Err(SwapError::Key(format!(
+            "{kind:?} execution blocked: claim/refund transaction builder is not implemented"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execution_blocked_when_claim_refund_builder_unavailable() {
+        assert!(ensure_claim_refund_builders_available(SwapKind::Submarine).is_err());
+        assert!(ensure_claim_refund_builders_available(SwapKind::Reverse).is_err());
+        assert!(ensure_claim_refund_builders_available(SwapKind::Chain).is_err());
+    }
+}

--- a/crates/satspath-swaps/src/lib.rs
+++ b/crates/satspath-swaps/src/lib.rs
@@ -2,6 +2,7 @@ pub mod ark_bridge;
 pub mod boltz_client;
 pub mod chain_swap;
 pub mod errors;
+pub mod execution_gate;
 pub mod reverse;
 pub mod submarine;
 pub mod swap_manager;
@@ -11,6 +12,7 @@ pub mod types;
 // Re-export common types
 pub use boltz_client::BoltzClient;
 pub use errors::{Result, SwapError};
+pub use execution_gate::{claim_refund_builders_available, ensure_claim_refund_builders_available};
 pub use swap_manager::SwapManager;
 pub use swap_store::SwapStore;
 pub use types::{PairFees, PairLimits, SwapKind, SwapResult, SwapStatus};

--- a/crates/satspath-swaps/src/reverse.rs
+++ b/crates/satspath-swaps/src/reverse.rs
@@ -68,7 +68,7 @@ pub async fn create_reverse(
     // Generate preimage (client secret — this is the HTLC secret)
     let mut preimage = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut preimage);
-    let preimage_hash: [u8; 32] = Sha256::digest(&preimage).into();
+    let preimage_hash: [u8; 32] = Sha256::digest(preimage).into();
 
     // Generate ephemeral claim keypair
     let secp = Secp256k1::new();
@@ -154,11 +154,11 @@ pub async fn wait_and_claim_reverse(
     match update.status {
         SwapStatus::TransactionLockupFailed => {
             store.update_status(swap_id, SwapStatus::TransactionLockupFailed, None)?;
-            return Err(SwapError::LockupAmountMismatch {
+            Err(SwapError::LockupAmountMismatch {
                 id: swap_id.to_string(),
                 got: 0,
                 expected: 0,
-            });
+            })
         }
         SwapStatus::TransactionConfirmed => {
             // Retrieve persisted record to get preimage and claim key
@@ -248,10 +248,10 @@ mod tests {
     fn preimage_and_hash_are_consistent() {
         let mut preimage = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut preimage);
-        let hash: [u8; 32] = Sha256::digest(&preimage).into();
+        let hash: [u8; 32] = Sha256::digest(preimage).into();
 
         // Verify deterministic
-        let hash2: [u8; 32] = Sha256::digest(&preimage).into();
+        let hash2: [u8; 32] = Sha256::digest(preimage).into();
         assert_eq!(hash, hash2);
 
         // Preimage hash is what we share with Boltz

--- a/crates/satspath-swaps/src/submarine.rs
+++ b/crates/satspath-swaps/src/submarine.rs
@@ -1,6 +1,4 @@
-use rand::RngCore;
 use secp256k1::{Secp256k1, SecretKey};
-use sha2::{Digest, Sha256};
 use std::time::Duration;
 
 use crate::boltz_client::{BoltzClient, SubmarineSwapRequest};
@@ -205,18 +203,19 @@ async fn attempt_submarine_refund(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use rand::RngCore;
+    use sha2::{Digest, Sha256};
 
     #[test]
     fn preimage_hash_is_sha256() {
         // Verify the preimage → hash relationship we'll use for Reverse swaps
         let mut preimage = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut preimage);
-        let hash: [u8; 32] = Sha256::digest(&preimage).into();
+        let hash: [u8; 32] = Sha256::digest(preimage).into();
         // Hash must be different from preimage
         assert_ne!(preimage, hash);
         // Re-hashing the hash should be different again
-        let double_hash: [u8; 32] = Sha256::digest(&hash).into();
+        let double_hash: [u8; 32] = Sha256::digest(hash).into();
         assert_ne!(hash, double_hash);
     }
 }

--- a/crates/satspath-swaps/src/swap_manager.rs
+++ b/crates/satspath-swaps/src/swap_manager.rs
@@ -9,7 +9,7 @@ use crate::errors::{Result, SwapError};
 use crate::reverse::{create_reverse, wait_and_claim_reverse, ReverseParams, ReverseSwapCreated};
 use crate::submarine::{create_submarine, wait_submarine, SubmarineParams, SubmarineSwapCreated};
 use crate::swap_store::SwapStore;
-use crate::types::{SwapKind, SwapRecord, SwapResult, SwapStatus};
+use crate::types::{SwapKind, SwapRecord, SwapResult};
 
 /// SwapManager orchestrates the lifecycle of Boltz swaps.
 ///

--- a/crates/satspath-swaps/src/swap_store.rs
+++ b/crates/satspath-swaps/src/swap_store.rs
@@ -17,38 +17,39 @@ struct SwapStoreFile {
 
 /// Persistent, encrypted local store for in-progress swap records.
 ///
-/// Stored at `~/.satspath/swaps.enc` (AES-256-GCM encrypted JSON).
-/// Falls back to plaintext `~/.satspath/swaps.json` in development mode.
+/// Stored at `.satspath/swaps.enc` (AES-256-GCM encrypted JSON).
+/// Plaintext storage is available only through explicit test/dev APIs.
 pub struct SwapStore {
     path: PathBuf,
     encryption_key: Option<[u8; 32]>,
+    allow_plaintext: bool,
 }
 
 impl SwapStore {
     /// Open the swap store at the default location (`.satspath/swaps.enc`).
     pub fn open() -> Result<Self> {
-        let path = satspath_dir()?.join("swaps.enc");
-        Ok(Self {
-            path,
-            encryption_key: None,
-        })
+        Err(SwapError::Encryption(
+            "SwapStore::open requires an encryption key; use open_encrypted(key)".into(),
+        ))
     }
 
     /// Open the store with an AES-256 encryption key derived from user password.
     /// The key should be derived via PBKDF2 (same scheme as ARK SDK's StorageCrypto).
-    pub fn open_with_key(key: [u8; 32]) -> Result<Self> {
+    pub fn open_encrypted(key: [u8; 32]) -> Result<Self> {
         let path = satspath_dir()?.join("swaps.enc");
         Ok(Self {
             path,
             encryption_key: Some(key),
+            allow_plaintext: false,
         })
     }
 
     /// Open a plaintext store at a custom path (for tests / dev).
-    pub fn open_plaintext(path: PathBuf) -> Self {
+    pub fn open_plaintext_for_tests(path: PathBuf) -> Self {
         Self {
             path,
             encryption_key: None,
+            allow_plaintext: true,
         }
     }
 
@@ -65,10 +66,14 @@ impl SwapStore {
             return Ok(SwapStoreFile::default());
         }
 
-        let json_bytes = if let Some(key) = &self.encryption_key {
+        let json_bytes = if self.allow_plaintext {
+            raw
+        } else if let Some(key) = &self.encryption_key {
             decrypt(key, &raw)?
         } else {
-            raw
+            return Err(SwapError::Encryption(
+                "refusing to read swap store without encryption key".into(),
+            ));
         };
 
         serde_json::from_slice(&json_bytes)
@@ -85,10 +90,14 @@ impl SwapStore {
 
         let json = serde_json::to_vec_pretty(store).map_err(SwapError::Json)?;
 
-        let to_write = if let Some(key) = &self.encryption_key {
+        let to_write = if self.allow_plaintext {
+            json
+        } else if let Some(key) = &self.encryption_key {
             encrypt(key, &json)?
         } else {
-            json
+            return Err(SwapError::Encryption(
+                "refusing to write swap store without encryption key".into(),
+            ));
         };
 
         std::fs::write(&self.path, to_write)?;
@@ -249,7 +258,7 @@ mod tests {
     #[test]
     fn upsert_and_retrieve() {
         let dir = tempdir().unwrap();
-        let store = SwapStore::open_plaintext(dir.path().join("swaps.enc"));
+        let store = SwapStore::open_plaintext_for_tests(dir.path().join("swaps.enc"));
 
         let rec = make_record("swap_001");
         store.upsert(&rec).unwrap();
@@ -262,7 +271,7 @@ mod tests {
     #[test]
     fn update_status() {
         let dir = tempdir().unwrap();
-        let store = SwapStore::open_plaintext(dir.path().join("swaps.enc"));
+        let store = SwapStore::open_plaintext_for_tests(dir.path().join("swaps.enc"));
 
         store.upsert(&make_record("swap_002")).unwrap();
         store
@@ -277,7 +286,7 @@ mod tests {
     #[test]
     fn list_pending() {
         let dir = tempdir().unwrap();
-        let store = SwapStore::open_plaintext(dir.path().join("swaps.enc"));
+        let store = SwapStore::open_plaintext_for_tests(dir.path().join("swaps.enc"));
 
         store.upsert(&make_record("swap_003")).unwrap();
         let mut done = make_record("swap_004");
@@ -305,5 +314,38 @@ mod tests {
         let plaintext = b"secret swap data";
         let enc = encrypt(&key, plaintext).unwrap();
         assert!(decrypt(&bad_key, &enc).is_err());
+    }
+
+    #[test]
+    fn default_open_fails_closed() {
+        assert!(SwapStore::open().is_err());
+    }
+
+    #[test]
+    fn plaintext_only_explicit_test_api() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("swaps.json");
+        let store = SwapStore::open_plaintext_for_tests(path.clone());
+        let mut rec = make_record("swap_plaintext");
+        rec.preimage_hex = Some("secret_preimage".into());
+        store.upsert(&rec).unwrap();
+        let bytes = std::fs::read(path).unwrap();
+        assert!(String::from_utf8_lossy(&bytes).contains("secret_preimage"));
+    }
+
+    #[test]
+    fn encrypted_roundtrip_store_hides_secrets() {
+        let dir = tempdir().unwrap();
+        std::env::set_var("SATSPATH_DIR", dir.path());
+        let store = SwapStore::open_encrypted([0x42u8; 32]).unwrap();
+        let mut rec = make_record("swap_encrypted");
+        rec.preimage_hex = Some("secret_preimage".into());
+        store.upsert(&rec).unwrap();
+
+        let bytes = std::fs::read(dir.path().join("swaps.enc")).unwrap();
+        assert!(!String::from_utf8_lossy(&bytes).contains("secret_preimage"));
+        let found = store.get("swap_encrypted").unwrap().unwrap();
+        assert_eq!(found.preimage_hex.as_deref(), Some("secret_preimage"));
+        std::env::remove_var("SATSPATH_DIR");
     }
 }

--- a/crates/satspath-swaps/src/swap_store.rs
+++ b/crates/satspath-swaps/src/swap_store.rs
@@ -37,11 +37,16 @@ impl SwapStore {
     /// The key should be derived via PBKDF2 (same scheme as ARK SDK's StorageCrypto).
     pub fn open_encrypted(key: [u8; 32]) -> Result<Self> {
         let path = satspath_dir()?.join("swaps.enc");
-        Ok(Self {
+        Ok(Self::open_encrypted_at(path, key))
+    }
+
+    /// Open an encrypted store at a custom path (for tests / dev).
+    pub fn open_encrypted_at(path: PathBuf, key: [u8; 32]) -> Self {
+        Self {
             path,
             encryption_key: Some(key),
             allow_plaintext: false,
-        })
+        }
     }
 
     /// Open a plaintext store at a custom path (for tests / dev).
@@ -52,6 +57,11 @@ impl SwapStore {
             encryption_key: None,
             allow_plaintext: true,
         }
+    }
+
+    /// Open a plaintext store at a custom path (for tests / dev).
+    pub fn open_plaintext_for_tests(path: PathBuf) -> Self {
+        Self::open_plaintext(path)
     }
 
     // ── Read ─────────────────────────────────────────────────────────────────

--- a/docs/ark_routes.md
+++ b/docs/ark_routes.md
@@ -1,0 +1,43 @@
+# Ark Routes
+
+SatsPath treats Ark as a public payment rail and keeps execution separate from
+route planning.
+
+## Direct Ark Receive
+
+An Ark receiver can publish an Ark public pointer:
+
+- Ark server URL,
+- compressed receiver public key,
+- optional VTXO pointer,
+- optional ownership proof.
+
+If the sender is compatible with the same Ark server, the route planner can
+produce an `ArkToArk` intent. This does not require Boltz, Lightning, or an
+on-chain swap. Current SatsPath CLI output is preview/intents unless explicitly
+testnet-executed and supported by the local bridge.
+
+## Ark Swap Routes
+
+Ark swaps are different from direct Ark receive:
+
+- `ArkToLightning` requires an offboard/submarine-style path.
+- `LightningToArk` requires an onboard/reverse path.
+- `ArkToOnchain` requires Ark offboard support.
+- `OnchainToArk` requires Ark onboard support.
+
+SatsPath does not call a normal Bitcoin address an Ark receive. If the Ark bridge
+cannot create or claim the required Ark-side object, the route is intent-only and
+fails closed for execution.
+
+## Current Status
+
+- Ark route planning exists.
+- Ark direct receive/send previews exist.
+- Ownership proof verification exists.
+- Mainnet execution is disabled.
+- Testnet execution is gated by `--testnet`, `--execute-testnet`, exact
+  confirmation text, profile validation, Ark ownership proof validation, bridge
+  availability, encrypted swap storage, and claim/refund builder availability.
+- Boltz Ark swap settlement is not implemented end to end.
+

--- a/docs/ark_swap_safety.md
+++ b/docs/ark_swap_safety.md
@@ -1,0 +1,42 @@
+# Ark Swap Safety
+
+Ark swap support is intentionally conservative.
+
+## Safety Rules
+
+- Mainnet execution is unavailable.
+- Preview mode never moves funds.
+- SatsPath never stores seed phrases, private keys, macaroons, certs, API keys,
+  or passwords in plaintext.
+- Swap execution must use encrypted `SwapStore`.
+- Plaintext swap storage is only available through an explicit test/dev API.
+- Claim/refund builders are required before executing a route that can strand
+  funds.
+
+## Execution Gates
+
+Commands that can move testnet funds require:
+
+- `--testnet`,
+- `--execute-testnet`,
+- `--confirm "execute testnet ark intent"`,
+- valid signed profile,
+- fresh profile,
+- valid Ark server URL,
+- compressed secp256k1 receiver pubkey,
+- verified Ark ownership proof,
+- supported Ark bridge method,
+- available claim/refund builder for swap routes.
+
+If any gate fails, execution is blocked and the command remains preview-only.
+
+## Not Implemented
+
+- Mainnet Ark execution.
+- Ark funding for Boltz submarine swaps.
+- Lightning-to-Ark delivery if Boltz can only deliver to a BTC address.
+- Ark onboard address creation and VTXO claiming.
+- Ark offboard execution to arbitrary BTC destinations.
+- Reverse/chain claim transaction builders.
+- Submarine refund transaction builder.
+


### PR DESCRIPTION
## What works now

- Adds Ark core protocol types for route kinds, receive pointers, ownership proofs, payment intents, intent status, and client validation reports.
- Adds Ark ownership challenge verification using the exact `satspath-proof:<alias>:ark:<ark_server>:<receiver_pubkey>:<nonce>` message format.
- Validates Ark server URLs, compressed secp256k1 receiver pubkeys, proof expiry, and malformed/wrong proof cases.
- Adds Ark route planning for `ArkToArk`, `ArkToLightning`, `LightningToArk`, `ArkToOnchain`, and `OnchainToArk`.
- Adds `satspath ark receive`, `satspath ark send`, and `satspath ark swap` CLI commands with testnet-only gating.
- Expands `ArkBridge` with typed JSON-RPC wrappers for receive pubkeys, challenge signing, receive VTXO requests, send VTXO, list VTXOs, and fee estimates.
- Fixes `SwapStore` so default open fails closed without an encryption key; plaintext is now explicit test/dev API only.
- Adds CI with fmt, tests, and clippy as required checks.

## Preview only

- Ark direct receive/send can produce safe route previews and validation reports.
- Ark swap routes are intent-level only unless explicitly testnet-executed and all safety gates pass.
- Missing Ark ownership proof results in preview-only behavior.
- Unsupported routes fail closed.

## What remains unimplemented

- Mainnet Ark execution is not implemented and no `--execute-mainnet` flag exists.
- Boltz Ark swap settlement is not implemented end to end.
- Ark funding for submarine swaps is blocked unless the bridge can offboard/fund the lockup path.
- Lightning-to-Ark remains intent-only unless an actual onboard/reverse path exists.
- Ark-to-on-chain and on-chain-to-Ark remain blocked without offboard/onboard bridge support.
- Reverse/chain claim transaction builders and submarine refund transaction builder remain unavailable, so execution is blocked before a route could strand funds.

## Safety guarantees

- Mainnet execution remains disabled.
- Any flow that could move funds requires `--testnet`, `--execute-testnet`, and exact confirmation text.
- Execution requires valid signed profile, fresh profile, valid Ark pointer, verified Ark ownership proof, supported bridge method, encrypted swap store, and available claim/refund builders.
- SatsPath does not store seed phrases, private keys, xprv/tprv, macaroons, certs, API keys, or passwords in plaintext.
- The CLI output distinguishes `verified` Ark ownership from unverified/preview-only claims.

## Tests run

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo run -q -p satspath-cli -- ark --help`

## Issues touched

- Ark ownership proof model and validation.
- Ark route planning and score route integration.
- Testnet-only execution gating.
- SwapStore plaintext write safety.
- CI coverage for Rust fmt/test/clippy.