### PR TITLE
feat(sdk): @satspath/p2p — Holepunch peer-to-peer profile resolution

### DIFF
--- a/sdk/satspath-p2p/.gitignore
+++ b/sdk/satspath-p2p/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+.DS_Store

--- a/sdk/satspath-p2p/README.md
+++ b/sdk/satspath-p2p/README.md
@@ -1,0 +1,116 @@
+# @satspath/p2p
+
+Resolve & serve **SatsPath signed payment profiles peer-to-peer** over the
+[Holepunch](https://holepunch.to) stack (Hyperswarm / HyperDHT), with NAT
+hole-punching — no central server and no local pre-registration of the receiver.
+
+A wallet that embeds this SDK automatically gets a **random node address** and can
+publish or resolve `user@domain` payment profiles directly between devices.
+
+> Transport + verification only. This SDK moves **only public, signed payment
+> profiles**. It never moves funds, signs Bitcoin transactions, or broadcasts.
+> Trust comes from the secp256k1 **signature**, not from the transport.
+
+## How it works
+
+```
+receiver device                         sender device
+───────────────                         ─────────────
+satspath export rodrigo@x.dev           node = new SatsPathP2PNode()
+   → rodrigo.json                       node.address  ← auto-generated, random
+node.publish(rodrigo.json)              await node.resolve("rodrigo@x.dev")
+   topic = sha256("…:rodrigo@x.dev")        │ join same topic, DHT lookup
+   announce on HyperDHT  ───────────────────┘ hole-punch + connect
+   serve profile to peers  ───────────────▶  receive → VERIFY SIGNATURE → return
+```
+
+- **Address.** Each node has an auto-generated random Ed25519 keypair (Hyperswarm's
+  Noise identity). `node.address` is its hex public key — *not* a Bitcoin key and
+  controls no funds.
+- **Discovery.** The DHT topic is `sha256("satspath:p2p:v1:" + canonicalAlias)`, so
+  publisher and resolver find each other from the alias alone.
+- **Trust.** A resolved profile is accepted only if `verifySignedProfile` passes
+  (secp256k1 ECDSA over `sha256(serde_json(profile))`, matching the Rust core) and
+  its alias matches the request. A tampered profile is rejected.
+
+## Install
+
+```bash
+npm install @satspath/p2p
+```
+
+## Wallet integration
+
+```js
+import { SatsPathP2PNode } from "@satspath/p2p";
+
+const node = new SatsPathP2PNode();
+console.log("my P2P address:", node.address); // auto-generated, random
+
+// ── Receiver: publish your signed profile (from `satspath export`) ──
+import { readFileSync } from "node:fs";
+const signed = JSON.parse(readFileSync("rodrigo.json", "utf8"));
+await node.publish(signed); // announces on the DHT, serves to peers
+
+// ── Sender (another device): resolve by alias, get a VERIFIED profile ──
+const profile = await node.resolve("rodrigo@satspath.dev", { timeoutMs: 20000 });
+// profile.profile.methods → route/pay with your own wallet
+```
+
+To persist a node's address across restarts, pass a saved keypair:
+
+```js
+import { generateNodeKeyPair } from "@satspath/p2p";
+const keyPair = generateNodeKeyPair(); // store keyPair.secretKey securely (it is NOT a wallet key)
+const node = new SatsPathP2PNode({ keyPair });
+```
+
+## Try it on two computers
+
+On the **receiver's** machine (in the SatsPath repo, build the CLI first):
+
+```bash
+satspath export rodrigo@satspath.dev > rodrigo.json
+cd sdk/satspath-p2p && npm install
+node examples/publish.mjs ../../rodrigo.json     # leave running
+```
+
+On the **sender's** machine (different computer / network):
+
+```bash
+cd sdk/satspath-p2p && npm install
+node examples/resolve.mjs rodrigo@satspath.dev   # prints the verified profile
+```
+
+DHT announce + lookup typically takes a few seconds to ~30s on a cold start.
+
+## API
+
+| Export | Purpose |
+|--------|---------|
+| `new SatsPathP2PNode({ keyPair?, swarm? })` | A node with an auto-generated (or supplied) random address. |
+| `node.address` | The node's hex public-key address. |
+| `node.publish(signed)` | Announce + serve a signed profile on its alias topic. Rejects an unsigned/invalid profile. |
+| `node.resolve(alias, { timeoutMs })` | Resolve over the DHT; returns a **signature-verified** profile or rejects on timeout. |
+| `node.destroy()` | Tear down the swarm. |
+| `generateNodeKeyPair()` | A fresh random node keypair. |
+| `topicForAlias(alias)` | The 32-byte DHT topic for an alias. |
+| `verifySignedProfile(signed)` | Verify a SatsPath signature natively in JS. |
+
+## Tests
+
+```bash
+npm test
+```
+
+Unit tests cover topic determinism, address randomness, and **verifying a real
+Rust-signed profile fixture** (proving JS canonicalization matches the Rust core),
+plus tamper rejection. The live two-node DHT round-trip is exercised via the
+examples above (it needs network access to the DHT and is not a CI unit test).
+
+## Safety
+
+- No funds moved, nothing signed or broadcast — public signed profiles only.
+- The node keypair is a P2P identity, **not** a wallet seed/spending key.
+- A profile is trusted only after its signature verifies; the DHT/transport is
+  never trusted on its own.

--- a/sdk/satspath-p2p/examples/publish.mjs
+++ b/sdk/satspath-p2p/examples/publish.mjs
@@ -1,0 +1,30 @@
+// Serve a signed profile peer-to-peer. Run on the receiver's machine.
+//
+//   satspath export rodrigo@satspath.dev > rodrigo.json
+//   node examples/publish.mjs rodrigo.json
+//
+// Leave it running; senders elsewhere can resolve the alias over the DHT.
+
+import { readFileSync } from "node:fs";
+
+import { SatsPathP2PNode } from "../src/index.js";
+
+const file = process.argv[2];
+if (!file) {
+  console.error("usage: node examples/publish.mjs <signed-profile.json>");
+  process.exit(1);
+}
+
+const signed = JSON.parse(readFileSync(file, "utf8"));
+const node = new SatsPathP2PNode();
+
+console.log("SatsPath P2P node address:", node.address);
+const { topic } = await node.publish(signed);
+console.log(`Publishing ${signed.profile.alias}`);
+console.log("DHT topic:", topic);
+console.log("Serving over Holepunch. Press Ctrl+C to stop.");
+
+process.on("SIGINT", async () => {
+  await node.destroy();
+  process.exit(0);
+});

--- a/sdk/satspath-p2p/examples/resolve.mjs
+++ b/sdk/satspath-p2p/examples/resolve.mjs
@@ -1,0 +1,29 @@
+// Resolve a SatsPath alias peer-to-peer over the DHT. Run on the sender's machine
+// (a different computer/network from the publisher):
+//
+//   node examples/resolve.mjs rodrigo@satspath.dev
+//
+// Prints the verified signed profile, or exits non-zero on failure/timeout.
+
+import { SatsPathP2PNode } from "../src/index.js";
+
+const alias = process.argv[2];
+if (!alias) {
+  console.error("usage: node examples/resolve.mjs <alias>");
+  process.exit(1);
+}
+
+const node = new SatsPathP2PNode();
+console.log("SatsPath P2P node address:", node.address);
+console.log(`Resolving ${alias} over Holepunch...`);
+
+try {
+  const signed = await node.resolve(alias, { timeoutMs: 20000 });
+  console.log("✓ Resolved and signature-verified:");
+  console.log(JSON.stringify(signed, null, 2));
+} catch (e) {
+  console.error("✗", e.message);
+  process.exitCode = 1;
+} finally {
+  await node.destroy();
+}

--- a/sdk/satspath-p2p/package-lock.json
+++ b/sdk/satspath-p2p/package-lock.json
@@ -1,0 +1,710 @@
+{
+  "name": "@satspath/p2p",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@satspath/p2p",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "hyperdht": "^6.20.0",
+        "hyperswarm": "^4.11.7"
+      }
+    },
+    "node_modules/@hyperswarm/secret-stream": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@hyperswarm/secret-stream/-/secret-stream-6.9.1.tgz",
+      "integrity": "sha512-xb0S5y3YJwBakD77JOGBHlBxdp63mHClZoXBYoLv+9wH8e054ESKlmQptWqjJK5dv5VMUIVYOJB4MaOpB0JdGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.1.0",
+        "hypercore-crypto": "^3.3.1",
+        "noise-curve-ed": "^2.0.1",
+        "noise-handshake": "^4.0.0",
+        "sodium-secretstream": "^1.1.0",
+        "sodium-universal": "^5.0.0",
+        "streamx": "^2.14.0",
+        "timeout-refresh": "^2.0.0",
+        "unslab": "^1.3.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/adaptive-timeout": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/adaptive-timeout/-/adaptive-timeout-1.0.1.tgz",
+      "integrity": "sha512-+seGiBtHqbnyZ0Quq/ZGxxwP66153WBABawa07/QeyuPFzbduPBjiGQAyCiriiLDzt3dkbMBskSlfqtRwblK8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xache": "^1.2.1"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-addon-resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.0.tgz",
+      "integrity": "sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-ansi-escapes": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bare-ansi-escapes/-/bare-ansi-escapes-2.2.3.tgz",
+      "integrity": "sha512-02ES4/E2RbrtZSnHJ9LntBhYkLA6lPpSEeP8iqS3MccBIVhVBlEmruF1I7HZqx5Q8aiTeYfQVeqmrU9YO2yYoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-stream": "^2.6.5"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-assert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bare-assert/-/bare-assert-1.2.0.tgz",
+      "integrity": "sha512-c6uvgvTJBspTDxtVnPgrBKmLgcpW3Fp72NVKDLg6oT4QjQbhGtvrkHMhGYMK1sh4vjBHOBmuUalyt9hSzV37fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-inspect": "^3.1.2"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-inspect": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/bare-inspect/-/bare-inspect-3.1.4.tgz",
+      "integrity": "sha512-jfW5KRA84o3REpI6Vr4nbvMn+hqVAw8GU1mMdRwUsY5yJovQamxYeKGVKGqdzs+8ZbG4jRzGUXP/3Ji/DnqfPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-ansi-escapes": "^2.1.0",
+        "bare-type": "^1.0.0"
+      },
+      "engines": {
+        "bare": ">=1.18.0"
+      }
+    },
+    "node_modules/bare-module-resolve": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.2.tgz",
+      "integrity": "sha512-j+hiD5k99qec4KjJvYsI67q5AOBifmy9JG3oeMVxTmvrhn2sIdp8StrUvZu4YNgwTpO+NhniQG16N1ETDe1k5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.3.tgz",
+      "integrity": "sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-semver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
+      "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-type/-/bare-type-1.1.0.tgz",
+      "integrity": "sha512-LdtnnEEYldOc87Dr4GpsKnStStZk3zfgoEMXy8yvEZkXrcCv9RtYDrUYWFsBQHtaB0s1EUWmcvS6XmEZYIj3Bw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.2.0"
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/bits-to-bytes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bits-to-bytes/-/bits-to-bytes-1.3.0.tgz",
+      "integrity": "sha512-OJoHTpFXS9bXHBCekGTByf3MqM8CGblBDIduKQeeVVeiU9dDWywSSirXIBYGgg3d1zbVuvnMa1vD4r6PA0kOKg==",
+      "license": "ISC",
+      "dependencies": {
+        "b4a": "^1.5.0"
+      }
+    },
+    "node_modules/blind-relay": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/blind-relay/-/blind-relay-1.6.1.tgz",
+      "integrity": "sha512-38YmKCl/m9NcTkwueBbcGIt9Zx3IT/Q9Nsluu6C5Gur6PqfE0zWPhPwCzia1hri/g0ICYxrqkgLtEaoWD5WeSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-events": "^2.2.0",
+        "bits-to-bytes": "^1.3.0",
+        "compact-encoding": "^3.0.0",
+        "compact-encoding-bitfield": "^1.0.0",
+        "protomux": "^3.5.1",
+        "sodium-universal": "^5.0.0",
+        "streamx": "^2.15.1"
+      }
+    },
+    "node_modules/bogon": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bogon/-/bogon-1.3.0.tgz",
+      "integrity": "sha512-04tu0G/v0f2HPuQlSfhO635WwHDBCaITJ490rhxH9ttUlgPqOirZVKV02YB6NvPf5VkmbqJCm3bnZwrPk/eDSg==",
+      "license": "MIT",
+      "dependencies": {
+        "compact-encoding": "^3.0.0",
+        "compact-encoding-net": "^1.2.0"
+      }
+    },
+    "node_modules/compact-encoding": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.3.0.tgz",
+      "integrity": "sha512-e64XyzlBvTRJ3iScuU/U2w25Dglkm7fhrRbrGaHIwuTlNnzjRKMaQBCVl7mJRvZg7wI5a9wX1IVTXCuaAANNkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.3.0"
+      }
+    },
+    "node_modules/compact-encoding-bitfield": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding-bitfield/-/compact-encoding-bitfield-1.1.0.tgz",
+      "integrity": "sha512-F6wliSKHi50BsBStmnsRJAzJgYSIYzdfSe3M0oHj4uQ1RcctJK/NQVD7wF51bj/DBMne2i5gUxrGUFkNZQns5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compact-encoding": "^3.0.0"
+      }
+    },
+    "node_modules/compact-encoding-net": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding-net/-/compact-encoding-net-1.3.0.tgz",
+      "integrity": "sha512-HIYjL3aMiSENApR691aMLngXt6rkTHb9HUkEukcx3YwIZpoMUVXHXyjBzoo9kVwC7KakooBA1RRWb46Cu6qtAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compact-encoding": "^3.0.0"
+      }
+    },
+    "node_modules/dht-rpc": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/dht-rpc/-/dht-rpc-6.27.0.tgz",
+      "integrity": "sha512-NsfgRlFDQnkA2+H+hJXMPLmBOn/TSIIc0cRMV8q42M4xc1uAXWtpvIIQsONF5tYcYC6px0bslrUGideN1h4S4A==",
+      "license": "MIT",
+      "dependencies": {
+        "adaptive-timeout": "^1.0.1",
+        "b4a": "^1.6.1",
+        "bare-events": "^2.2.0",
+        "compact-encoding": "^3.0.0",
+        "compact-encoding-net": "^1.2.0",
+        "fast-fifo": "^1.1.0",
+        "kademlia-routing-table": "^1.0.1",
+        "nat-sampler": "^1.0.1",
+        "sodium-universal": "^5.0.0",
+        "streamx": "^2.13.2",
+        "time-ordered-set": "^2.0.0",
+        "udx-native": "^1.5.3"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/generate-object-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-2.0.0.tgz",
+      "integrity": "sha512-KwuURPyqn2Mz8DdV29pJwQu0Y7tcsbkULr82eeOcY/ZllFK6I9Wm8dsRByIu7CKWlFi9BdW1b3mcXMp/kQBQsw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "node_modules/generate-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/generate-string/-/generate-string-1.0.1.tgz",
+      "integrity": "sha512-IfTY0dKZM43ACyGvXkbG7De7WY7MxTS5VO6Juhe8oJKpCmrYYXoqp/cJMskkpi0k9H8wuXq0H+eI898/BCqvXg==",
+      "license": "MIT"
+    },
+    "node_modules/hypercore-crypto": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-3.7.0.tgz",
+      "integrity": "sha512-SWxobptQf2V/+ZLCCDRTXqFzGfTPIkNIuDyLKXpEMfcpJ1/ec94N9aWgylHcWOHmRt14ng/KR7z0BugebWHK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.6",
+        "compact-encoding": "^3.0.0",
+        "sodium-universal": "^5.0.0"
+      }
+    },
+    "node_modules/hypercore-id-encoding": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/hypercore-id-encoding/-/hypercore-id-encoding-1.3.0.tgz",
+      "integrity": "sha512-W6sHdGo5h7LXEsoWfKf/KfuROZmZRQDlGqJF2EPHW+noCK66Vvr0+zE6cL0vqQi18s0kQPeN7Sq3QyR0Ytc2VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.5.3",
+        "z32": "^1.0.0"
+      }
+    },
+    "node_modules/hyperdht": {
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.32.0.tgz",
+      "integrity": "sha512-Y/SibEN7wue0E8ydh8lx9IX7SOE9o00b6tufPA7hRxAafXsisWUBrW36fIHdyxg148T4Z3olrooOGZDZ89LYag==",
+      "license": "MIT",
+      "dependencies": {
+        "@hyperswarm/secret-stream": "^6.6.2",
+        "b4a": "^1.3.1",
+        "bare-events": "^2.2.0",
+        "blind-relay": "^1.3.0",
+        "bogon": "^1.0.0",
+        "compact-encoding": "^3.0.0",
+        "dht-rpc": "^6.15.1",
+        "hypercore-crypto": "^3.3.0",
+        "hypercore-id-encoding": "^1.2.0",
+        "hyperdht-address": "^1.0.1",
+        "noise-curve-ed": "^2.0.0",
+        "noise-handshake": "^4.0.0",
+        "record-cache": "^1.1.1",
+        "safety-catch": "^1.0.1",
+        "signal-promise": "^1.0.3",
+        "sodium-universal": "^5.0.1",
+        "streamx": "^2.16.1",
+        "unslab": "^1.3.0",
+        "xache": "^1.1.0"
+      },
+      "bin": {
+        "hyperdht": "bin.js"
+      }
+    },
+    "node_modules/hyperdht-address": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hyperdht-address/-/hyperdht-address-1.1.1.tgz",
+      "integrity": "sha512-Mu/+7SW2cwvHxMXswa5mOrhrS5BJyntViAuB25k8d8wNtA8eAPs4LaIq6TwN1SS/KQY02h1r+gM8cQeN/k360w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compact-encoding": "^3.0.0",
+        "hyperschema": "^1.20.1"
+      }
+    },
+    "node_modules/hyperschema": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/hyperschema/-/hyperschema-1.21.0.tgz",
+      "integrity": "sha512-lEnIbLTUQf7w6FU6X+R3yUJhBwCzF4ewRnAaYOrPdcVWe1rbOf94PzMiXb5pBKxroCXzlrPLxVujxAsTrrHc8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.0.1",
+        "compact-encoding": "^3.0.0",
+        "generate-object-property": "^2.0.0",
+        "generate-string": "^1.0.1"
+      }
+    },
+    "node_modules/hyperswarm": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-4.17.0.tgz",
+      "integrity": "sha512-oe86sK961Ueg7rvDN/veFwG8xH+Iv6vObPhGDkPJcDVxk/NduW41ZhAcVDnHzRbm7S0eLU7WaDUvehOYoKSpRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1",
+        "bare-events": "^2.2.0",
+        "hyperdht": "^6.21.0",
+        "safety-catch": "^1.0.2",
+        "shuffled-priority-queue": "^2.1.0",
+        "streamx": "^2.22.1",
+        "unslab": "^1.3.0"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
+    "node_modules/kademlia-routing-table": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/kademlia-routing-table/-/kademlia-routing-table-1.0.6.tgz",
+      "integrity": "sha512-Ve6jwIlUCYvUzBnXnzVRHDZCFgXURW9gmF3r7n05kZs/2rNbLHXwGdcq0qIaSwdmJCvtosgR4JensnVU65hzNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
+    "node_modules/nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==",
+      "license": "ISC"
+    },
+    "node_modules/nat-sampler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nat-sampler/-/nat-sampler-1.0.1.tgz",
+      "integrity": "sha512-yQvyNN7xbqR8crTKk3U8gRgpcV1Az+vfCEijiHu9oHHsnIl8n3x+yXNHl42M6L3czGynAVoOT9TqBfS87gDdcw==",
+      "license": "MIT"
+    },
+    "node_modules/noise-curve-ed": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/noise-curve-ed/-/noise-curve-ed-2.1.0.tgz",
+      "integrity": "sha512-zAzJx+VwZM3w6EA1hTmDhJfvAnCeBQn/1FAeZ0LtGxCcCtlAK/uJXQVF/eDVUOaAZ286lHlx77WJ+qj9SmsRRg==",
+      "license": "ISC",
+      "dependencies": {
+        "b4a": "^1.1.0",
+        "nanoassert": "^2.0.0",
+        "sodium-universal": "^5.0.0"
+      }
+    },
+    "node_modules/noise-handshake": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/noise-handshake/-/noise-handshake-4.2.0.tgz",
+      "integrity": "sha512-9O/VTNX/E2/AToyMTTDU0J/4WhaXMTdqc2DHs9vf+snoZ0cenSBq0dNYTVV1snYYEkmo6QeRrYMxtqtoYnY+LA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.1.0",
+        "nanoassert": "^2.0.0",
+        "sodium-universal": "^5.0.0"
+      }
+    },
+    "node_modules/protomux": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/protomux/-/protomux-3.11.0.tgz",
+      "integrity": "sha512-Ze43XaNHbL6zQ/zJwVYvue7Aj8pDB1HNnISsrFhAur3291Y+Iu2fMhOpySD73J/32BoBIUYrhl07lJsBR/fUVA==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1",
+        "compact-encoding": "^3.0.0",
+        "queue-tick": "^1.0.0",
+        "safety-catch": "^1.0.1",
+        "unslab": "^1.3.0"
+      }
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "license": "MIT"
+    },
+    "node_modules/record-cache": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.2.0.tgz",
+      "integrity": "sha512-kyy3HWCez2WrotaL3O4fTn0rsIdfRKOdQQcEJ9KpvmKmbffKVvwsloX063EgRUlpJIXHiDQFhJcTbZequ2uTZw==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1"
+      }
+    },
+    "node_modules/require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-addon-resolve": "^1.3.0"
+      },
+      "engines": {
+        "bare": ">=1.10.0"
+      }
+    },
+    "node_modules/safety-catch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.3.tgz",
+      "integrity": "sha512-Zq+J1TefpoEq/HTUabo0YXX5MNvttjWYODGohgPBO2jfko8Wqx3JYMgE823szDFVamdH5PlpByvfiWScTdSYDA==",
+      "license": "MIT"
+    },
+    "node_modules/shuffled-priority-queue": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/shuffled-priority-queue/-/shuffled-priority-queue-2.1.0.tgz",
+      "integrity": "sha512-xhdh7fHyMsr0m/w2kDfRJuBFRS96b9l8ZPNWGaQ+PMvnUnZ/Eh+gJJ9NsHBd7P9k0399WYlCLzsy18EaMfyadA==",
+      "license": "MIT",
+      "dependencies": {
+        "unordered-set": "^2.0.1"
+      }
+    },
+    "node_modules/signal-promise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/signal-promise/-/signal-promise-1.0.3.tgz",
+      "integrity": "sha512-WBgv0UnIq2C+Aeh0/n+IRpP6967eIx9WpynTUoiW3isPpfe1zu2LJzyfXdo9Tgef8yR/sGjcMvoUXD7EYdiz+g==",
+      "license": "MIT"
+    },
+    "node_modules/sodium-native": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.1.0.tgz",
+      "integrity": "sha512-3RxgyWyJlhTsABPnJVpCI5CoTDANZTqqFrEPqr+kjfnRaBihpVtMUE3yTF40ukdoB1APXeoBNKF3MzZAIHg39g==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-assert": "^1.2.0",
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.1"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/sodium-secretstream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sodium-secretstream/-/sodium-secretstream-1.2.0.tgz",
+      "integrity": "sha512-q/DbraNFXm1KfCiiZvapmz5UC3OlpirYFIvBK2MhGaOFSb3gRyk8OXTi17UI9SGfshQNCpsVvlopogbzZNyW6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.1.1",
+        "sodium-universal": "^5.0.0"
+      }
+    },
+    "node_modules/sodium-universal": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-5.0.1.tgz",
+      "integrity": "sha512-rv+aH+tnKB5H0MAc2UadHShLMslpJsc4wjdnHRtiSIEYpOetCgu8MS4ExQRia+GL/MK3uuCyZPeEsi+J3h+Q+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "sodium-native": "^5.0.1"
+      },
+      "peerDependencies": {
+        "sodium-javascript": "~0.8.0"
+      },
+      "peerDependenciesMeta": {
+        "sodium-javascript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/time-ordered-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/time-ordered-set/-/time-ordered-set-2.0.1.tgz",
+      "integrity": "sha512-VJEKmgSN2UiOLB8BpN8Sh2b9LGMHTP5OPrQRpnKjvOheOyzk0mufbjzjKTIG2gO4A+Y+vDJ+0TcLbpUmMLsg8A==",
+      "license": "MIT"
+    },
+    "node_modules/timeout-refresh": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-2.0.1.tgz",
+      "integrity": "sha512-SVqEcMZBsZF9mA78rjzCrYrUs37LMJk3ShZ851ygZYW1cMeIjs9mL57KO6Iv5mmjSQnOe/29/VAfGXo+oRCiVw==",
+      "license": "MIT"
+    },
+    "node_modules/udx-native": {
+      "version": "1.20.7",
+      "resolved": "https://registry.npmjs.org/udx-native/-/udx-native-1.20.7.tgz",
+      "integrity": "sha512-FNG0QpnSt0us2xbLP5mmG5Q0UKdLYjKHuh2eR9VrJSFmoZMzeszYLLhK12+iq5x3eq/rgoGG/lLwPn7IDAr6pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.5.0",
+        "bare-events": "^2.2.0",
+        "require-addon": "^1.1.0",
+        "streamx": "^2.22.0"
+      },
+      "engines": {
+        "bare": ">=1.17.4"
+      }
+    },
+    "node_modules/unordered-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.1.tgz",
+      "integrity": "sha512-eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg==",
+      "license": "MIT"
+    },
+    "node_modules/unslab": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/unslab/-/unslab-1.3.0.tgz",
+      "integrity": "sha512-YATkfKAFj47kTzmiQrWXMyRvaVrHsW6MEALa4bm+FhiA2YG4oira+Z3DXN6LrYOYn2Y8eO94Lwl9DOHjs1FpoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.6"
+      }
+    },
+    "node_modules/which-runtime": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.4.0.tgz",
+      "integrity": "sha512-0ugbP4CJW4e2D20jvEcC4973dCgIaHI4Rw1PT+26U9zEve7FyYdWAIwUnoeOYvoCfn+wXHoHTKb1KhkYlb60Pw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/xache": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/xache/-/xache-1.2.1.tgz",
+      "integrity": "sha512-igRS6jPreJ54ABdzhh4mCDXcz+XMaWO2q1ABRV2yWYuk29jlp8VT7UBdCqNkX7rpYBbXsebVVKkwIuYZjyZNqA==",
+      "license": "MIT"
+    },
+    "node_modules/z32": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/z32/-/z32-1.1.0.tgz",
+      "integrity": "sha512-1WUHy+VS6d0HPNspDxvLssBbeQjXMjSnpv0vH82vRAUfg847NmX3OXozp/hRP5jPhxBbrVzrgvAt+UsGNzRFQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.5.3"
+      }
+    }
+  }
+}

--- a/sdk/satspath-p2p/package.json
+++ b/sdk/satspath-p2p/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@satspath/p2p",
+  "version": "0.1.0",
+  "description": "Resolve & serve SatsPath signed payment profiles peer-to-peer over the Holepunch stack (Hyperswarm/HyperDHT) with NAT hole-punching. Transport + signature verification only — never moves funds.",
+  "type": "module",
+  "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js",
+    "example:publish": "node examples/publish.mjs",
+    "example:resolve": "node examples/resolve.mjs"
+  },
+  "dependencies": {
+    "@noble/curves": "^1.9.7",
+    "@noble/hashes": "^1.8.0",
+    "hyperdht": "^6.20.0",
+    "hyperswarm": "^4.11.7"
+  },
+  "license": "MIT"
+}

--- a/sdk/satspath-p2p/src/identity.js
+++ b/sdk/satspath-p2p/src/identity.js
@@ -1,0 +1,21 @@
+// Node identity ("address") for the P2P layer.
+//
+// Each SatsPath P2P node has an auto-generated, random Ed25519 keypair used by
+// Hyperswarm's Noise handshake. Its public key (hex) is the node's stable
+// **address** on the DHT. This is NOT a Bitcoin key and controls no funds — it
+// only identifies the encrypted P2P connection.
+
+import DHT from "hyperdht";
+
+/**
+ * Generate a fresh random node keypair.
+ * @returns {{ publicKey: Uint8Array, secretKey: Uint8Array }}
+ */
+export function generateNodeKeyPair() {
+  return DHT.keyPair();
+}
+
+/** Hex-encode a node public key into its display address. */
+export function addressFromPublicKey(publicKey) {
+  return Buffer.from(publicKey).toString("hex");
+}

--- a/sdk/satspath-p2p/src/index.js
+++ b/sdk/satspath-p2p/src/index.js
@@ -1,0 +1,14 @@
+// @satspath/p2p — resolve & serve SatsPath signed payment profiles peer-to-peer
+// over the Holepunch stack (Hyperswarm / HyperDHT), with NAT hole-punching.
+//
+// This is a transport + verification layer. It moves only public, signed payment
+// profiles. It never moves funds, signs Bitcoin transactions, or broadcasts.
+
+export { SatsPathP2PNode } from "./node.js";
+export { generateNodeKeyPair, addressFromPublicKey } from "./identity.js";
+export { topicForAlias } from "./topic.js";
+export {
+  verifySignedProfile,
+  canonicalProfileBytes,
+  canonicalAlias,
+} from "./profile.js";

--- a/sdk/satspath-p2p/src/node.js
+++ b/sdk/satspath-p2p/src/node.js
@@ -1,0 +1,163 @@
+// SatsPathP2PNode — publish/resolve signed payment profiles over Holepunch.
+//
+// Uses Hyperswarm (HyperDHT) for DHT discovery + NAT hole-punching. A receiver
+// `publish()`es their signed profile on the topic derived from their alias; a
+// sender `resolve()`s the same alias, connects through the DHT, and receives the
+// profile — which is **verified by signature** before being returned.
+//
+// Safety: this layer only moves public, signed payment profiles. It never moves
+// funds, signs Bitcoin transactions, or broadcasts anything.
+
+import Hyperswarm from "hyperswarm";
+
+import { topicForAlias } from "./topic.js";
+import { canonicalAlias, verifySignedProfile } from "./profile.js";
+import { addressFromPublicKey } from "./identity.js";
+
+export class SatsPathP2PNode {
+  /**
+   * @param {object} [opts]
+   * @param {{ publicKey: Uint8Array, secretKey: Uint8Array }} [opts.keyPair]
+   *        Persisted node identity. Omit to auto-generate a random one.
+   * @param {object} [opts.swarm] Extra options forwarded to Hyperswarm.
+   */
+  constructor(opts = {}) {
+    this.swarm = new Hyperswarm({ keyPair: opts.keyPair, ...opts.swarm });
+    /** @type {Map<string, object>} topicHex -> signed profile we serve */
+    this._serving = new Map();
+    this.swarm.on("connection", (conn) => this._onServerConnection(conn));
+  }
+
+  /** This node's auto-generated random address (hex public key). */
+  get address() {
+    return addressFromPublicKey(this.swarm.keyPair.publicKey);
+  }
+
+  // When a peer connects, push every profile we're serving (each framed).
+  _onServerConnection(conn) {
+    conn.on("error", () => {});
+    for (const signed of this._serving.values()) {
+      writeFrame(conn, new TextEncoder().encode(JSON.stringify(signed)));
+    }
+  }
+
+  /**
+   * Announce a signed profile on its alias topic and serve it to peers.
+   * @param {object} signed `{ profile, signature }` from `satspath export`.
+   * @returns {Promise<{ topic: string, address: string }>}
+   */
+  async publish(signed) {
+    if (!verifySignedProfile(signed)) {
+      throw new Error("refusing to publish a profile with an invalid signature");
+    }
+    const topic = topicForAlias(signed.profile.alias);
+    this._serving.set(hex(topic), signed);
+    const discovery = this.swarm.join(topic, { server: true, client: false });
+    await discovery.flushed();
+    // Ensure the DHT announce has fully propagated before returning.
+    await this.swarm.flush();
+    return { topic: hex(topic), address: this.address };
+  }
+
+  /**
+   * Resolve an alias over the DHT and return its verified signed profile.
+   * @param {string} alias
+   * @param {object} [opts]
+   * @param {number} [opts.timeoutMs=15000]
+   * @returns {Promise<object>} verified `{ profile, signature }`
+   */
+  async resolve(alias, opts = {}) {
+    const timeoutMs = opts.timeoutMs ?? 15000;
+    const topic = topicForAlias(alias);
+
+    return await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(new Error(`resolve("${alias}") timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      const onConn = (conn) => {
+        conn.on("error", () => {});
+        readFrame(conn)
+          .then((buf) => {
+            let signed;
+            try {
+              signed = JSON.parse(new TextDecoder().decode(buf));
+            } catch {
+              return; // ignore malformed; wait for another peer
+            }
+            // Trust comes from the signature, not the transport.
+            if (!verifySignedProfile(signed)) return;
+            if (canonicalAlias(signed.profile.alias) !== canonicalAlias(alias)) return;
+            cleanup();
+            resolve(signed);
+          })
+          .catch(() => {});
+      };
+
+      const cleanup = () => {
+        clearTimeout(timer);
+        this.swarm.off("connection", onConn);
+      };
+
+      // Attach the listener BEFORE joining so a connection that fires during the
+      // DHT lookup/flush is never missed.
+      this.swarm.on("connection", onConn);
+      const discovery = this.swarm.join(topic, { client: true, server: false });
+      discovery
+        .flushed()
+        .then(() => this.swarm.flush())
+        .catch(() => {});
+    });
+  }
+
+  /** Tear down the swarm and all DHT connections. */
+  async destroy() {
+    await this.swarm.destroy();
+  }
+}
+
+// ─── length-prefixed framing (4-byte LE length + payload) ─────────────────────
+
+function writeFrame(conn, payload) {
+  const len = new Uint8Array(4);
+  new DataView(len.buffer).setUint32(0, payload.length, true);
+  conn.write(len);
+  conn.write(payload);
+}
+
+function readFrame(conn) {
+  return new Promise((resolve, reject) => {
+    let acc = new Uint8Array(0);
+    let need = -1;
+    const onData = (data) => {
+      acc = concat(acc, data);
+      if (need < 0 && acc.length >= 4) {
+        need = new DataView(acc.buffer, acc.byteOffset, 4).getUint32(0, true);
+        acc = acc.subarray(4);
+      }
+      if (need >= 0 && acc.length >= need) {
+        conn.off("data", onData);
+        conn.off("error", onErr);
+        resolve(acc.subarray(0, need));
+      }
+    };
+    const onErr = (e) => {
+      conn.off("data", onData);
+      reject(e);
+    };
+    conn.on("data", onData);
+    conn.on("error", onErr);
+  });
+}
+
+function concat(a, b) {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
+
+function hex(bytes) {
+  return Buffer.from(bytes).toString("hex");
+}

--- a/sdk/satspath-p2p/src/profile.js
+++ b/sdk/satspath-p2p/src/profile.js
@@ -1,0 +1,38 @@
+// SatsPath signed-profile verification, native in JS.
+//
+// SatsPath signs `SHA-256(serde_json::to_string(profile))` with secp256k1 ECDSA
+// (DER signature, compressed pubkey). JavaScript preserves object key insertion
+// order, so `JSON.stringify(profile)` of a profile parsed from `satspath export`
+// reproduces Rust's exact canonical bytes — verified against a real Rust
+// signature in the test suite. No re-implementation of serde is required.
+
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { sha256 } from "@noble/hashes/sha256";
+
+/** Canonical alias form used for topic derivation and matching. */
+export function canonicalAlias(alias) {
+  return String(alias).trim().toLowerCase();
+}
+
+/** The exact bytes SatsPath signed: UTF-8 of compact JSON, in field order. */
+export function canonicalProfileBytes(profile) {
+  return new TextEncoder().encode(JSON.stringify(profile));
+}
+
+/**
+ * Verify a SatsPath `SignedPaymentProfile` `{ profile, signature }`.
+ * Returns `true` only if the secp256k1 signature is valid for the profile's
+ * `identity_pubkey`. Never throws.
+ */
+export function verifySignedProfile(signed) {
+  try {
+    const pubkey = signed?.profile?.identity_pubkey;
+    const signature = signed?.signature;
+    if (typeof pubkey !== "string" || typeof signature !== "string") return false;
+    const msgHash = sha256(canonicalProfileBytes(signed.profile));
+    const sig = secp256k1.Signature.fromDER(signature);
+    return secp256k1.verify(sig, msgHash, pubkey);
+  } catch {
+    return false;
+  }
+}

--- a/sdk/satspath-p2p/src/topic.js
+++ b/sdk/satspath-p2p/src/topic.js
@@ -1,0 +1,20 @@
+// Discovery topic derivation for SatsPath over Holepunch.
+//
+// A SatsPath alias maps deterministically to a 32-byte DHT topic. The receiver
+// announces on this topic; the sender looks it up. The topic reveals only a hash
+// of the (already public) alias.
+
+import { sha256 } from "@noble/hashes/sha256";
+
+import { canonicalAlias } from "./profile.js";
+
+const TOPIC_PREFIX = "satspath:p2p:v1:";
+
+/**
+ * The 32-byte Hyperswarm/HyperDHT topic for a SatsPath alias.
+ * @param {string} alias e.g. "rodrigo@satspath.dev"
+ * @returns {Uint8Array} 32 bytes
+ */
+export function topicForAlias(alias) {
+  return sha256(new TextEncoder().encode(TOPIC_PREFIX + canonicalAlias(alias)));
+}

--- a/sdk/satspath-p2p/test-fixture.json
+++ b/sdk/satspath-p2p/test-fixture.json
@@ -1,0 +1,18 @@
+{
+  "profile": {
+    "alias": "rodrigo@satspath.dev",
+    "identity_pubkey": "0229a82f4045b4acf4e8cf5290124ba7ed9fe05299d90918d4d51228fd5ac7f097",
+    "methods": [
+      {
+        "type": "Lightning",
+        "label": "Lightning Address",
+        "lightning_address": "trujasx@blink.sv",
+        "lnurl": null,
+        "bolt12": null,
+        "receiver_pubkey": null
+      }
+    ],
+    "updated_at": 1782775961
+  },
+  "signature": "304402201427dfbe2954cee6c04a86ed52d68fc27673152532e5cd5fdf384aebe91515e002205e1a00371652b4a68db91d62e1d81d34413261ffd15b90b82c4e71ba86840e67"
+}

--- a/sdk/satspath-p2p/test/sdk.test.js
+++ b/sdk/satspath-p2p/test/sdk.test.js
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import { topicForAlias } from "../src/topic.js";
+import { generateNodeKeyPair, addressFromPublicKey } from "../src/identity.js";
+import { verifySignedProfile, canonicalAlias } from "../src/profile.js";
+
+const fixture = JSON.parse(
+  readFileSync(new URL("../test-fixture.json", import.meta.url), "utf8"),
+);
+
+test("topic is deterministic and 32 bytes", () => {
+  const a = topicForAlias("rodrigo@satspath.dev");
+  const b = topicForAlias("RODRIGO@satspath.dev "); // case/space-insensitive
+  assert.equal(a.length, 32);
+  assert.deepEqual(a, b);
+});
+
+test("different aliases get different topics", () => {
+  assert.notDeepEqual(
+    topicForAlias("alice@example.com"),
+    topicForAlias("bob@example.com"),
+  );
+});
+
+test("node keypair is random (a bit different each time)", () => {
+  const a = addressFromPublicKey(generateNodeKeyPair().publicKey);
+  const b = addressFromPublicKey(generateNodeKeyPair().publicKey);
+  assert.equal(a.length, 64); // 32-byte ed25519 pubkey, hex
+  assert.notEqual(a, b);
+});
+
+test("verifies a real Rust-signed profile", () => {
+  // Proves JS canonicalization matches Rust's serde_json::to_string(profile).
+  assert.equal(verifySignedProfile(fixture), true);
+});
+
+test("rejects a tampered profile (alias changed after signing)", () => {
+  const tampered = JSON.parse(JSON.stringify(fixture));
+  tampered.profile.alias = "evil@hacker.com";
+  assert.equal(verifySignedProfile(tampered), false);
+});
+
+test("rejects a tampered signature", () => {
+  const tampered = JSON.parse(JSON.stringify(fixture));
+  tampered.signature = tampered.signature.slice(0, -2) + "00";
+  assert.equal(verifySignedProfile(tampered), false);
+});
+
+test("rejects malformed input without throwing", () => {
+  assert.equal(verifySignedProfile(null), false);
+  assert.equal(verifySignedProfile({}), false);
+  assert.equal(verifySignedProfile({ profile: {}, signature: "zz" }), false);
+});
+
+test("canonicalAlias normalizes case and whitespace", () => {
+  assert.equal(canonicalAlias("  Rodrigo@Satspath.DEV "), "rodrigo@satspath.dev");
+});


### PR DESCRIPTION
Adds **`@satspath/p2p`** — a Node SDK a wallet embeds to resolve & serve SatsPath signed payment profiles **peer-to-peer over the Holepunch stack** (Hyperswarm/HyperDHT), with NAT hole-punching. No central server, no local pre-registration of the receiver.

### What a wallet gets
```js
import { SatsPathP2PNode } from "@satspath/p2p";
const node = new SatsPathP2PNode();
console.log(node.address);                 // auto-generated random address (hex ed25519 pubkey)

await node.publish(signedProfile);         // receiver: announce on the DHT, serve to peers
const p = await node.resolve("rodrigo@satspath.dev"); // sender: DHT lookup → hole-punch → VERIFIED profile
```

- **Random address** auto-generated per node (Hyperswarm Noise keypair) — not a Bitcoin key, controls no funds.
- **Discovery** topic = `sha256("satspath:p2p:v1:" + canonicalAlias)` → publisher/resolver meet from the alias alone.
- **Trust = signature, not transport.** A resolved profile is returned only after `verifySignedProfile` passes (secp256k1 ECDSA over `sha256(serde_json(profile))`, matching the Rust core) and its alias matches. Tampered profiles are rejected.

### Verified
- **Live two-node DHT round-trip works**: a second node resolved a published alias over the real DHT and signature-verified it.
- **8 unit tests pass** — incl. verifying a *real Rust-signed* fixture (proves JS canonicalization matches Rust) + tamper rejection.

### Notes
- Pure JS addition under `sdk/satspath-p2p` (like `ark-bridge/`); **no Rust touched**, so cargo CI is unaffected. `node_modules` gitignored.
- Bridges cleanly to the CLI: `satspath export` produces the profile to publish; resolved profiles feed your own routing/wallet.
- Transport + verification only — no funds moved, nothing signed or broadcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)