### PR TITLE
feat(cli): add safe SatsPath wallet profile manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/satspath-router",
     "crates/satspath-cli",
     "crates/satspath-swaps",
+    "crates/satspathd",
 ]
 resolver = "2"
 

--- a/crates/satspath-cli/Cargo.toml
+++ b/crates/satspath-cli/Cargo.toml
@@ -22,7 +22,9 @@ chrono = { workspace = true }
 qrcode = { version = "0.14", default-features = false }
 reqwest = { workspace = true }
 url = { workspace = true }
+urlencoding = "2"
 secp256k1 = { workspace = true }
+tiny_http = "0.12"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/satspath-cli/src/commands/mod.rs
+++ b/crates/satspath-cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ mod quote;
 mod register;
 mod show;
 mod wallet;
+mod web;
 
 pub use ark::{cmd_ark_receive, cmd_ark_send, cmd_ark_swap, ArkSwapSide};
 pub use demo::cmd_demo;
@@ -32,6 +33,7 @@ pub use wallet::{
     cmd_wallet_add_ark, cmd_wallet_add_lightning, cmd_wallet_add_methods, cmd_wallet_add_onchain,
     cmd_wallet_init, cmd_wallet_publish, cmd_wallet_receive, cmd_wallet_show,
 };
+pub use web::cmd_web;
 
 use anyhow::Result;
 use satspath_core::registry::Registry;

--- a/crates/satspath-cli/src/commands/mod.rs
+++ b/crates/satspath-cli/src/commands/mod.rs
@@ -13,6 +13,7 @@ mod qr;
 mod quote;
 mod register;
 mod show;
+mod wallet;
 
 pub use ark::{cmd_ark_receive, cmd_ark_send, cmd_ark_swap, ArkSwapSide};
 pub use demo::cmd_demo;
@@ -27,6 +28,10 @@ pub use proofs::{cmd_attach_proof, cmd_prove};
 pub use quote::{cmd_quote, cmd_quote_json};
 pub use register::cmd_register;
 pub use show::cmd_show;
+pub use wallet::{
+    cmd_wallet_add_ark, cmd_wallet_add_lightning, cmd_wallet_add_methods, cmd_wallet_add_onchain,
+    cmd_wallet_init, cmd_wallet_publish, cmd_wallet_receive, cmd_wallet_show,
+};
 
 use anyhow::Result;
 use satspath_core::registry::Registry;

--- a/crates/satspath-cli/src/commands/wallet.rs
+++ b/crates/satspath-cli/src/commands/wallet.rs
@@ -1,0 +1,557 @@
+//! `satspath wallet` — a safe **receiver-profile** wallet.
+//!
+//! This wallet manages a SatsPath identity and **public receive pointers**
+//! (Lightning Address, on-chain address, Ark server/pubkey), signs a payment
+//! profile, and produces preview output. It is NOT a spending wallet:
+//!
+//! - It never moves funds, signs Bitcoin transactions, or broadcasts.
+//! - It never asks for, derives, or stores seeds, xprv/tprv, descriptors with
+//!   private data, macaroons, certs, API keys, passwords, or spending keys.
+//!
+//! The only secret it touches is the SatsPath **identity signing key** (used to
+//! sign public profiles), which lives in the existing gitignored, owner-only
+//! keystore — never in `wallet.json`.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use satspath_core::ark::validate_ark_server_url;
+use satspath_core::crypto::{
+    fingerprint_pubkey, generate_identity_keypair, sign_profile, verify_signed_profile,
+};
+use satspath_core::privacy::{mask_address, mask_identifier, mask_pubkey};
+use satspath_core::registry::Registry;
+use satspath_core::validation::{
+    assert_no_private_material, validate_bitcoin_address, validate_compressed_pubkey,
+    validate_lightning_address,
+};
+use satspath_core::{BitcoinNetwork, PaymentMethod, PaymentProfile};
+
+use super::{keystore, satspath_dir};
+
+/// The improved guidance shown when a local profile fails signature verification.
+const SIGNATURE_INVALID_HELP: &str =
+    "Signature invalid. The profile may be tampered or stale from an older schema. \
+     Re-run `satspath wallet add-methods` or recreate the local profile.";
+
+const WALLET_FILE: &str = "wallet.json";
+
+/// Local wallet state — **public data + the identity public key only**.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct WalletState {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    alias: Option<String>,
+    /// Identity *public* key (hex). The signing key stays in the keystore.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    identity_pubkey: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lightning_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    onchain_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ark_server: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ark_pubkey: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    created_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    updated_at: Option<i64>,
+}
+
+// ─── storage helpers ─────────────────────────────────────────────────────────
+
+fn wallet_path() -> std::path::PathBuf {
+    satspath_dir().join(WALLET_FILE)
+}
+
+fn ensure_dir() -> Result<()> {
+    std::fs::create_dir_all(satspath_dir())?;
+    Ok(())
+}
+
+fn open_registry() -> Result<Registry> {
+    ensure_dir()?;
+    Ok(Registry::open(&satspath_dir())?)
+}
+
+fn load_wallet() -> Result<WalletState> {
+    let path = wallet_path();
+    if !path.exists() {
+        return Ok(WalletState::default());
+    }
+    let raw = std::fs::read_to_string(&path)?;
+    Ok(serde_json::from_str(&raw)?)
+}
+
+fn save_wallet(state: &WalletState) -> Result<()> {
+    ensure_dir()?;
+    let json = serde_json::to_string_pretty(state)?;
+    // Defence in depth: never let private material reach wallet.json.
+    assert_no_private_material(&json).map_err(|e| anyhow::anyhow!("{e}"))?;
+    std::fs::write(wallet_path(), json)?;
+    Ok(())
+}
+
+fn now() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+// ─── profile building / signing ──────────────────────────────────────────────
+
+fn build_methods(state: &WalletState) -> Vec<PaymentMethod> {
+    let mut methods = Vec::new();
+    if let Some(addr) = &state.lightning_address {
+        methods.push(PaymentMethod::Lightning {
+            label: "Lightning Address".into(),
+            lightning_address: Some(addr.clone()),
+            lnurl: None,
+            bolt12: None,
+            receiver_pubkey: None,
+        });
+    }
+    if let Some(addr) = &state.onchain_address {
+        methods.push(PaymentMethod::Onchain {
+            label: "Bitcoin (mainnet)".into(),
+            network: BitcoinNetwork::Mainnet,
+            address: addr.clone(),
+            pubkey_hint: None,
+            descriptor_hint: None,
+        });
+    }
+    if let (Some(server), Some(pubkey)) = (&state.ark_server, &state.ark_pubkey) {
+        methods.push(PaymentMethod::Ark {
+            label: "Ark".into(),
+            server: server.clone(),
+            pubkey: pubkey.clone(),
+            vtxo_pointer: None,
+            proof: None,
+            expires_at: None,
+        });
+    }
+    methods
+}
+
+/// Build, sign, and persist the wallet's payment profile to the local registry.
+fn sign_and_store(state: &WalletState) -> Result<String> {
+    let alias = state.alias.as_ref().ok_or_else(|| {
+        anyhow::anyhow!("wallet has no alias yet — run `satspath wallet add-methods <alias> ...`")
+    })?;
+    let pubkey = state.identity_pubkey.as_ref().ok_or_else(|| {
+        anyhow::anyhow!("wallet not initialized — run `satspath wallet init` first")
+    })?;
+
+    let methods = build_methods(state);
+    if methods.is_empty() {
+        anyhow::bail!("no receive methods set — add at least a Lightning, on-chain, or Ark method");
+    }
+
+    let secret = keystore::load_identity_key(&satspath_dir(), pubkey)?;
+    let profile = PaymentProfile {
+        alias: alias.clone(),
+        identity_pubkey: pubkey.clone(),
+        methods,
+        updated_at: now(),
+        expires_at: None,
+        method_verifications: Vec::new(),
+    };
+    let signed = sign_profile(profile, &secret)?;
+    let fp = fingerprint_pubkey(pubkey)?;
+    open_registry()?
+        .update_profile(signed)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(fp)
+}
+
+// ─── commands ────────────────────────────────────────────────────────────────
+
+/// `satspath wallet init` — create/load the identity key.
+pub fn cmd_wallet_init() -> Result<()> {
+    ensure_dir()?;
+    let mut state = load_wallet()?;
+
+    if let Some(pubkey) = &state.identity_pubkey {
+        if keystore::load_identity_key(&satspath_dir(), pubkey).is_ok() {
+            println!("Wallet already initialized.");
+            println!("Identity fingerprint: {}", fingerprint_pubkey(pubkey)?);
+            print_receiver_warning();
+            return Ok(());
+        }
+    }
+
+    let kp = generate_identity_keypair();
+    let pubkey = hex::encode(kp.public_key.serialize());
+    keystore::save_identity_key(&satspath_dir(), &kp.secret_key)?;
+
+    state.identity_pubkey = Some(pubkey.clone());
+    state.created_at.get_or_insert(now());
+    state.updated_at = Some(now());
+    save_wallet(&state)?;
+
+    println!("Initialized SatsPath receiver wallet.");
+    println!("Identity fingerprint: {}", fingerprint_pubkey(&pubkey)?);
+    println!(
+        "Identity key stored in {} (gitignored, owner-only).",
+        satspath_dir().join("identity").display()
+    );
+    print_receiver_warning();
+    Ok(())
+}
+
+fn print_receiver_warning() {
+    println!();
+    println!("This is a receiver-profile wallet. It does not control or move funds.");
+}
+
+/// `satspath wallet add-methods <alias> [--lightning-address] [--onchain-address] [--ark-server --ark-pubkey]`
+pub fn cmd_wallet_add_methods(
+    alias: &str,
+    lightning_address: Option<&str>,
+    onchain_address: Option<&str>,
+    ark_server: Option<&str>,
+    ark_pubkey: Option<&str>,
+) -> Result<()> {
+    let mut state = load_wallet()?;
+    if state.identity_pubkey.is_none() {
+        anyhow::bail!("wallet not initialized — run `satspath wallet init` first");
+    }
+
+    if lightning_address.is_none()
+        && onchain_address.is_none()
+        && (ark_server.is_none() || ark_pubkey.is_none())
+    {
+        anyhow::bail!(
+            "provide at least one receive method (--lightning-address / --onchain-address / --ark-server + --ark-pubkey)"
+        );
+    }
+
+    state.alias = Some(alias.to_string());
+    if let Some(la) = lightning_address {
+        validate_lightning_address(la)
+            .map_err(|e| anyhow::anyhow!("invalid Lightning Address: {e}"))?;
+        state.lightning_address = Some(la.to_string());
+    }
+    if let Some(addr) = onchain_address {
+        validate_bitcoin_address(addr, BitcoinNetwork::Mainnet)
+            .map_err(|e| anyhow::anyhow!("invalid Bitcoin address: {e}"))?;
+        state.onchain_address = Some(addr.to_string());
+    }
+    match (ark_server, ark_pubkey) {
+        (Some(server), Some(pubkey)) => {
+            validate_ark_server_url(server)
+                .map_err(|e| anyhow::anyhow!("invalid Ark server: {e}"))?;
+            validate_compressed_pubkey(pubkey)
+                .map_err(|e| anyhow::anyhow!("invalid Ark pubkey: {e}"))?;
+            state.ark_server = Some(server.to_string());
+            state.ark_pubkey = Some(pubkey.to_string());
+        }
+        (None, None) => {}
+        _ => anyhow::bail!("--ark-server and --ark-pubkey must be provided together"),
+    }
+    state.updated_at = Some(now());
+
+    let fp = sign_and_store(&state)?;
+    save_wallet(&state)?;
+
+    println!("Signed and saved profile for {}.", mask_identifier(alias));
+    println!("Identity fingerprint: {fp}");
+    println!("Receive methods:");
+    for m in build_methods(&state) {
+        println!("  - {}", m.method_name());
+    }
+    Ok(())
+}
+
+/// `satspath wallet add-lightning <addr>` — incremental update.
+pub fn cmd_wallet_add_lightning(addr: &str) -> Result<()> {
+    update_one(|state| {
+        validate_lightning_address(addr)
+            .map_err(|e| anyhow::anyhow!("invalid Lightning Address: {e}"))?;
+        state.lightning_address = Some(addr.to_string());
+        Ok(())
+    })
+}
+
+/// `satspath wallet add-onchain <addr>` — incremental update.
+pub fn cmd_wallet_add_onchain(addr: &str) -> Result<()> {
+    update_one(|state| {
+        validate_bitcoin_address(addr, BitcoinNetwork::Mainnet)
+            .map_err(|e| anyhow::anyhow!("invalid Bitcoin address: {e}"))?;
+        state.onchain_address = Some(addr.to_string());
+        Ok(())
+    })
+}
+
+/// `satspath wallet add-ark --server <url> --pubkey <hex>` — incremental update.
+pub fn cmd_wallet_add_ark(server: &str, pubkey: &str) -> Result<()> {
+    update_one(|state| {
+        validate_ark_server_url(server).map_err(|e| anyhow::anyhow!("invalid Ark server: {e}"))?;
+        validate_compressed_pubkey(pubkey)
+            .map_err(|e| anyhow::anyhow!("invalid Ark pubkey: {e}"))?;
+        state.ark_server = Some(server.to_string());
+        state.ark_pubkey = Some(pubkey.to_string());
+        Ok(())
+    })
+}
+
+fn update_one<F: FnOnce(&mut WalletState) -> Result<()>>(f: F) -> Result<()> {
+    let mut state = load_wallet()?;
+    if state.identity_pubkey.is_none() {
+        anyhow::bail!("wallet not initialized — run `satspath wallet init` first");
+    }
+    if state.alias.is_none() {
+        anyhow::bail!("set your alias first: `satspath wallet add-methods <alias> ...`");
+    }
+    f(&mut state)?;
+    state.updated_at = Some(now());
+    let fp = sign_and_store(&state)?;
+    save_wallet(&state)?;
+    println!("Updated and re-signed profile (fingerprint {fp}).");
+    Ok(())
+}
+
+/// `satspath wallet show [--debug]`
+pub fn cmd_wallet_show(debug: bool) -> Result<()> {
+    let state = load_wallet()?;
+    let Some(pubkey) = &state.identity_pubkey else {
+        anyhow::bail!("wallet not initialized — run `satspath wallet init` first");
+    };
+
+    let mask_id = |s: &str| {
+        if debug {
+            s.to_string()
+        } else {
+            mask_identifier(s)
+        }
+    };
+    let mask_addr = |s: &str| {
+        if debug {
+            s.to_string()
+        } else {
+            mask_address(s)
+        }
+    };
+    let mask_pk = |s: &str| if debug { s.to_string() } else { mask_pubkey(s) };
+
+    println!(
+        "Alias: {}",
+        state
+            .alias
+            .as_deref()
+            .map(&mask_id)
+            .unwrap_or_else(|| "(not set)".into())
+    );
+    println!("Identity fingerprint: {}", fingerprint_pubkey(pubkey)?);
+    if let Some(la) = &state.lightning_address {
+        println!("Lightning: {}", mask_id(la));
+    }
+    if let Some(addr) = &state.onchain_address {
+        println!("On-chain: {}", mask_addr(addr));
+    }
+    if let Some(server) = &state.ark_server {
+        println!("Ark server: {}", mask_addr(server));
+    }
+    if let Some(pk) = &state.ark_pubkey {
+        println!("Ark pubkey: {}", mask_pk(pk));
+    }
+
+    // Verify the stored signed profile.
+    if let Some(alias) = &state.alias {
+        match open_registry()?.resolve_alias(alias) {
+            Ok(signed) => {
+                if verify_signed_profile(signed)? {
+                    println!("Profile signature: valid");
+                } else {
+                    println!("Profile signature: INVALID");
+                    println!("{SIGNATURE_INVALID_HELP}");
+                }
+            }
+            Err(_) => println!("Profile signature: (no signed profile saved yet)"),
+        }
+    }
+    Ok(())
+}
+
+/// `satspath wallet publish [alias]` — export the signed profile for P2P sharing.
+pub fn cmd_wallet_publish(alias: Option<&str>) -> Result<()> {
+    let state = load_wallet()?;
+    let alias = alias
+        .map(str::to_string)
+        .or_else(|| state.alias.clone())
+        .ok_or_else(|| {
+            anyhow::anyhow!("no alias — pass one or run `satspath wallet add-methods` first")
+        })?;
+
+    let registry = open_registry()?;
+    let signed = registry
+        .resolve_alias(&alias)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    if !verify_signed_profile(signed)? {
+        anyhow::bail!("{SIGNATURE_INVALID_HELP}");
+    }
+
+    let out_path = satspath_dir().join(format!("{}-profile.json", sanitize(&alias)));
+    std::fs::write(&out_path, serde_json::to_string_pretty(signed)?)?;
+
+    println!("Exported signed profile to {}", out_path.display());
+    println!();
+    println!("Publish it peer-to-peer with the Holepunch SDK:");
+    println!("  cd sdk/satspath-p2p && npm install");
+    println!("  node examples/publish.mjs {}", out_path.display());
+    println!();
+    println!("Another device can then resolve it:");
+    println!("  node examples/resolve.mjs {alias}");
+    Ok(())
+}
+
+fn sanitize(alias: &str) -> String {
+    alias
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+/// `satspath wallet receive <alias> <amount_sats> --json` — preview-only output.
+pub async fn cmd_wallet_receive(alias: &str, amount_sats: u64, json: bool) -> Result<()> {
+    let preview = build_receive_preview(alias, amount_sats).await;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&preview)?);
+    } else {
+        println!("Status:  {}", preview.status);
+        println!("Mode:    {}", preview.mode);
+        println!("Alias:   {}", mask_identifier(&preview.alias));
+        if let Some(rail) = &preview.selected_rail {
+            println!("Rail:    {rail}");
+        }
+        if let Some(reason) = &preview.reason {
+            println!("Reason:  {reason}");
+        }
+        for w in &preview.warnings {
+            println!("  ⚠  {w}");
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct WalletReceivePreview {
+    status: String,
+    mode: String,
+    alias: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fingerprint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    selected_rail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    qr: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    warnings: Vec<String>,
+}
+
+async fn build_receive_preview(alias: &str, amount_sats: u64) -> WalletReceivePreview {
+    use satspath_router::QuoteResponse;
+
+    let warnings = vec![
+        "No funds moved by SatsPath".to_string(),
+        "Payment execution happens in external wallet".to_string(),
+    ];
+    let base = |status: &str| WalletReceivePreview {
+        status: status.to_string(),
+        mode: "preview_only".to_string(),
+        alias: alias.to_string(),
+        fingerprint: None,
+        selected_rail: None,
+        qr: None,
+        reason: None,
+        warnings: warnings.clone(),
+    };
+
+    match satspath_router::quote(alias, amount_sats).await {
+        QuoteResponse::Ok {
+            recipient,
+            selected_method,
+            qr,
+            reason,
+            ..
+        } => WalletReceivePreview {
+            fingerprint: recipient.fingerprint,
+            selected_rail: Some(selected_method.method_name().to_string()),
+            qr: Some(qr),
+            reason: Some(reason),
+            ..base("ok")
+        },
+        QuoteResponse::NoRoute { reason } => WalletReceivePreview {
+            reason: Some(reason),
+            ..base("no_route")
+        },
+        QuoteResponse::InvalidSignature { recipient } => WalletReceivePreview {
+            fingerprint: recipient.fingerprint,
+            reason: Some(SIGNATURE_INVALID_HELP.to_string()),
+            ..base("invalid_signature")
+        },
+        QuoteResponse::NotRegistered { .. } => WalletReceivePreview {
+            reason: Some("alias is not registered in the local wallet/registry".to_string()),
+            ..base("not_registered")
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wallet_state_serializes_without_private_fields() {
+        let state = WalletState {
+            alias: Some("rodrigo@satspath.dev".into()),
+            identity_pubkey: Some("02abc".into()),
+            lightning_address: Some("rodrigo@getalby.com".into()),
+            onchain_address: Some("bc1qexample".into()),
+            ark_server: Some("https://ark.example.com".into()),
+            ark_pubkey: Some("02def".into()),
+            created_at: Some(1),
+            updated_at: Some(2),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        // Public-only: assert_no_private_material accepts it.
+        assert!(assert_no_private_material(&json).is_ok());
+        for term in ["xprv", "tprv", "seed", "mnemonic", "macaroon", "secret_key"] {
+            assert!(!json.contains(term));
+        }
+    }
+
+    #[test]
+    fn build_methods_preserves_public_receive_pointers() {
+        let state = WalletState {
+            lightning_address: Some("a@b.com".into()),
+            onchain_address: Some("bc1qx".into()),
+            ark_server: Some("https://ark.x".into()),
+            ark_pubkey: Some("02ab".into()),
+            ..Default::default()
+        };
+        let methods = build_methods(&state);
+        assert_eq!(methods.len(), 3);
+        assert!(methods
+            .iter()
+            .any(|m| matches!(m, PaymentMethod::Lightning { .. })));
+        assert!(methods
+            .iter()
+            .any(|m| matches!(m, PaymentMethod::Onchain { .. })));
+        assert!(methods
+            .iter()
+            .any(|m| matches!(m, PaymentMethod::Ark { .. })));
+    }
+
+    #[test]
+    fn ark_requires_both_server_and_pubkey() {
+        let state = WalletState {
+            ark_server: Some("https://ark.x".into()),
+            ark_pubkey: None,
+            ..Default::default()
+        };
+        // Only one of the pair → no Ark method built.
+        assert!(!build_methods(&state)
+            .iter()
+            .any(|m| matches!(m, PaymentMethod::Ark { .. })));
+    }
+}

--- a/crates/satspath-cli/src/commands/wallet.rs
+++ b/crates/satspath-cli/src/commands/wallet.rs
@@ -131,6 +131,88 @@ fn build_methods(state: &WalletState) -> Vec<PaymentMethod> {
     methods
 }
 
+/// A privacy-preserving receive descriptor for the local UI: a **masked** alias,
+/// the chosen rail, and a public receive payload. No raw identifier or identity
+/// pubkey is exposed; nothing is fetched from the network.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReceiveQr {
+    /// Masked alias, e.g. `r***@gmail.com`.
+    pub alias: String,
+    /// The selected rail name (Lightning / Onchain / Ark).
+    pub rail: String,
+    /// The public receive payload to encode in the QR.
+    pub payload: String,
+}
+
+/// Compute the wallet owner's preferred receive payload, entirely locally.
+///
+/// Route selection prefers Lightning (instant) → on-chain → Ark. With no amount
+/// it returns a reusable receive pointer. No mempool/LNURL/DNS calls are made, so
+/// the operation stays fully private.
+pub fn local_receive_qr(amount_sats: Option<u64>) -> Result<ReceiveQr> {
+    let state = load_wallet()?;
+    let alias = state.alias.clone().ok_or_else(|| {
+        anyhow::anyhow!("no wallet profile yet — run `satspath wallet add-methods`")
+    })?;
+    let methods = build_methods(&state);
+    let method = methods
+        .iter()
+        .find(|m| matches!(m, PaymentMethod::Lightning { .. }))
+        .or_else(|| {
+            methods
+                .iter()
+                .find(|m| matches!(m, PaymentMethod::Onchain { .. }))
+        })
+        .or_else(|| {
+            methods
+                .iter()
+                .find(|m| matches!(m, PaymentMethod::Ark { .. }))
+        })
+        .ok_or_else(|| anyhow::anyhow!("no receive methods — run `satspath wallet add-methods`"))?;
+
+    Ok(ReceiveQr {
+        alias: mask_identifier(&alias),
+        rail: method.method_name().to_string(),
+        payload: receive_payload_for(method, amount_sats)?,
+    })
+}
+
+fn receive_payload_for(method: &PaymentMethod, amount_sats: Option<u64>) -> Result<String> {
+    let payload = match method {
+        PaymentMethod::Lightning {
+            lightning_address: Some(addr),
+            ..
+        } => addr.clone(),
+        PaymentMethod::Lightning {
+            lnurl: Some(url), ..
+        } => url.clone(),
+        PaymentMethod::Onchain { address, .. } => match amount_sats {
+            Some(sats) => format!("bitcoin:{address}?amount={}", sats_to_btc(sats)),
+            None => format!("bitcoin:{address}"),
+        },
+        PaymentMethod::Ark { server, pubkey, .. } => match amount_sats {
+            Some(sats) => format!(
+                "satspath:ark?server={}&pubkey={}&amount={}",
+                urlencoding::encode(server),
+                urlencoding::encode(pubkey),
+                sats
+            ),
+            None => format!(
+                "satspath:ark?server={}&pubkey={}",
+                urlencoding::encode(server),
+                urlencoding::encode(pubkey)
+            ),
+        },
+        _ => anyhow::bail!("selected method has no receive pointer"),
+    };
+    assert_no_private_material(&payload).map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(payload)
+}
+
+fn sats_to_btc(sats: u64) -> String {
+    format!("{}.{:08}", sats / 100_000_000, sats % 100_000_000)
+}
+
 /// Build, sign, and persist the wallet's payment profile to the local registry.
 fn sign_and_store(state: &WalletState) -> Result<String> {
     let alias = state.alias.as_ref().ok_or_else(|| {

--- a/crates/satspath-cli/src/commands/web.rs
+++ b/crates/satspath-cli/src/commands/web.rs
@@ -1,0 +1,153 @@
+//! `satspath web` — a minimal, private "Receive" web UI.
+//!
+//! Serves a single elegant black-and-white page with one button. Clicking it
+//! computes the wallet owner's preferred receive route locally and returns the
+//! QR. Everything stays private:
+//!
+//! - binds to `127.0.0.1` only (never exposed on the network),
+//! - makes no external calls (no mempool, LNURL, DNS, or web fonts),
+//! - shows only a masked alias — never the raw identifier or identity pubkey,
+//! - generates the QR locally; no funds move, nothing is signed or broadcast.
+
+use anyhow::Result;
+use qrcode::{Color, QrCode};
+
+use super::wallet::local_receive_qr;
+
+const INDEX_HTML: &str = include_str!("web_index.html");
+
+pub fn cmd_web(port: u16) -> Result<()> {
+    let addr = format!("127.0.0.1:{port}");
+    let server = tiny_http::Server::http(&addr)
+        .map_err(|e| anyhow::anyhow!("could not bind {addr}: {e}"))?;
+
+    println!("SatsPath Receive UI → http://{addr}");
+    println!("Private + local only (127.0.0.1). Press Ctrl+C to stop.");
+
+    for request in server.incoming_requests() {
+        let url = request.url();
+        let response = if url == "/" || url.starts_with("/?") {
+            html_response(INDEX_HTML)
+        } else if url.starts_with("/api/receive") {
+            json_response(&receive_json())
+        } else {
+            tiny_http::Response::from_string("not found")
+                .with_status_code(404)
+                .boxed()
+        };
+        // A broken pipe to one client must not take the server down.
+        let _ = request.respond(response);
+    }
+    Ok(())
+}
+
+fn receive_json() -> String {
+    match local_receive_qr(None) {
+        Ok(rec) => match qr_svg(&rec.payload) {
+            Ok(svg) => format!(
+                r#"{{"alias":{},"rail":{},"payload":{},"qr_svg":{}}}"#,
+                json_str(&rec.alias),
+                json_str(&rec.rail),
+                json_str(&rec.payload),
+                json_str(&svg),
+            ),
+            Err(e) => error_json(&e.to_string()),
+        },
+        Err(e) => error_json(&e.to_string()),
+    }
+}
+
+fn error_json(msg: &str) -> String {
+    format!(r#"{{"error":{}}}"#, json_str(msg))
+}
+
+/// Minimal JSON string escaping (we only emit a handful of fields).
+fn json_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Render a payload as a self-contained black-and-white SVG QR (no deps beyond
+/// the QR matrix). Black modules on a white quiet zone.
+fn qr_svg(data: &str) -> Result<String> {
+    let code =
+        QrCode::new(data.as_bytes()).map_err(|e| anyhow::anyhow!("could not encode QR: {e}"))?;
+    let width = code.width();
+    let colors = code.to_colors();
+    let quiet = 4usize;
+    let size = width + quiet * 2;
+
+    let mut rects = String::new();
+    for y in 0..width {
+        for x in 0..width {
+            if colors[y * width + x] == Color::Dark {
+                rects.push_str(&format!(
+                    "<rect x='{}' y='{}' width='1' height='1'/>",
+                    x + quiet,
+                    y + quiet
+                ));
+            }
+        }
+    }
+
+    Ok(format!(
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 {size} {size}' \
+         shape-rendering='crispEdges'><rect width='100%' height='100%' fill='#fff'/>\
+         <g fill='#000'>{rects}</g></svg>"
+    ))
+}
+
+fn html_response(body: &str) -> tiny_http::ResponseBox {
+    tiny_http::Response::from_string(body)
+        .with_header(header("Content-Type", "text/html; charset=utf-8"))
+        .boxed()
+}
+
+fn json_response(body: &str) -> tiny_http::ResponseBox {
+    tiny_http::Response::from_string(body)
+        .with_header(header("Content-Type", "application/json"))
+        .boxed()
+}
+
+fn header(key: &str, value: &str) -> tiny_http::Header {
+    tiny_http::Header::from_bytes(key.as_bytes(), value.as_bytes()).expect("static header is valid")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qr_svg_is_black_and_white_svg() {
+        let svg = qr_svg("bitcoin:bc1qexample?amount=0.00100000").unwrap();
+        assert!(svg.starts_with("<svg"));
+        assert!(svg.contains("fill='#000'"));
+        assert!(svg.contains("fill='#fff'"));
+        assert!(svg.contains("<rect"));
+    }
+
+    #[test]
+    fn json_string_escapes_quotes_and_controls() {
+        assert_eq!(json_str("a\"b"), "\"a\\\"b\"");
+        assert_eq!(json_str("a\nb"), "\"a\\nb\"");
+    }
+
+    #[test]
+    fn error_json_is_valid() {
+        let v: serde_json::Value = serde_json::from_str(&error_json("boom")).unwrap();
+        assert_eq!(v["error"], "boom");
+    }
+}

--- a/crates/satspath-cli/src/commands/web_index.html
+++ b/crates/satspath-cli/src/commands/web_index.html
@@ -1,0 +1,181 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="referrer" content="no-referrer" />
+<title>SatsPath · Recibir</title>
+<style>
+  :root {
+    --ink: #0a0a0a;
+    --paper: #ffffff;
+    --hair: #e6e6e6;
+    --muted: #8a8a8a;
+    --serif: "Hoefler Text", "Iowan Old Style", "Palatino Linotype", Palatino,
+      "Times New Roman", Georgia, serif;
+    --mono: "SF Mono", "JetBrains Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--serif);
+    -webkit-font-smoothing: antialiased;
+    display: grid;
+    place-items: center;
+    min-height: 100vh;
+  }
+  main {
+    width: 100%;
+    max-width: 420px;
+    padding: 48px 28px;
+    text-align: center;
+  }
+  .brand {
+    font-size: 13px;
+    letter-spacing: 0.42em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 18px;
+  }
+  h1 {
+    font-weight: 500;
+    font-size: 44px;
+    letter-spacing: 0.01em;
+    margin: 0 0 6px;
+  }
+  .tagline {
+    font-style: italic;
+    color: var(--muted);
+    font-size: 16px;
+    margin: 0 0 44px;
+  }
+  button#receive {
+    appearance: none;
+    cursor: pointer;
+    font-family: var(--serif);
+    font-size: 17px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--paper);
+    background: var(--ink);
+    border: 1px solid var(--ink);
+    border-radius: 0;
+    padding: 18px 46px;
+    transition: background 0.18s ease, color 0.18s ease, transform 0.05s ease;
+  }
+  button#receive:hover { background: var(--paper); color: var(--ink); }
+  button#receive:active { transform: translateY(1px); }
+  button#receive:disabled { opacity: 0.4; cursor: progress; }
+
+  .card {
+    margin-top: 40px;
+    border: 1px solid var(--ink);
+    padding: 26px 24px 22px;
+    opacity: 0;
+    transform: translateY(8px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+  }
+  .card.show { opacity: 1; transform: none; }
+  .qr {
+    width: 232px;
+    height: 232px;
+    margin: 0 auto 18px;
+  }
+  .qr svg { width: 100%; height: 100%; display: block; }
+  .rail {
+    font-size: 12px;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .alias { font-size: 18px; margin: 6px 0 16px; }
+  .payload {
+    font-family: var(--mono);
+    font-size: 11px;
+    line-height: 1.6;
+    color: #333;
+    word-break: break-all;
+    border-top: 1px solid var(--hair);
+    padding-top: 14px;
+    margin: 0 0 10px;
+  }
+  .copy {
+    appearance: none;
+    cursor: pointer;
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    background: none;
+    border: 1px solid var(--hair);
+    color: var(--muted);
+    padding: 7px 14px;
+  }
+  .copy:hover { border-color: var(--ink); color: var(--ink); }
+  .err { color: var(--ink); font-style: italic; margin-top: 28px; }
+  footer {
+    margin-top: 40px;
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    color: var(--muted);
+  }
+</style>
+</head>
+<body>
+<main>
+  <div class="brand">SatsPath</div>
+  <h1>Recibir</h1>
+  <p class="tagline">Tu ruta, tu QR. Privado y local.</p>
+
+  <button id="receive">Recibir</button>
+
+  <div class="card" id="card" hidden>
+    <div class="qr" id="qr"></div>
+    <div class="rail" id="rail"></div>
+    <div class="alias" id="alias"></div>
+    <p class="payload" id="payload"></p>
+    <button class="copy" id="copy">Copiar</button>
+  </div>
+
+  <div class="err" id="err" hidden></div>
+
+  <footer>No mueve fondos · No firma · No transmite · 127.0.0.1</footer>
+</main>
+
+<script>
+  const $ = (id) => document.getElementById(id);
+  const btn = $("receive");
+
+  btn.addEventListener("click", async () => {
+    btn.disabled = true;
+    $("err").hidden = true;
+    try {
+      const r = await fetch("/api/receive");
+      const data = await r.json();
+      if (!r.ok || data.error) throw new Error(data.error || "fallo al calcular la ruta");
+      $("qr").innerHTML = data.qr_svg;
+      $("rail").textContent = data.rail;
+      $("alias").textContent = data.alias;
+      $("payload").textContent = data.payload;
+      const card = $("card");
+      card.hidden = false;
+      requestAnimationFrame(() => card.classList.add("show"));
+      $("copy").onclick = async () => {
+        await navigator.clipboard.writeText(data.payload);
+        $("copy").textContent = "Copiado";
+        setTimeout(() => ($("copy").textContent = "Copiar"), 1400);
+      };
+    } catch (e) {
+      const err = $("err");
+      err.textContent = e.message;
+      err.hidden = false;
+    } finally {
+      btn.disabled = false;
+    }
+  });
+</script>
+</body>
+</html>

--- a/crates/satspath-cli/src/main.rs
+++ b/crates/satspath-cli/src/main.rs
@@ -170,8 +170,62 @@ enum Command {
         command: DnsCommand,
     },
 
+    /// Safe receiver-profile wallet: manage public receive methods, sign a
+    /// profile, preview. Never moves funds or stores spending keys.
+    Wallet {
+        #[command(subcommand)]
+        command: WalletCommand,
+    },
+
     /// Run the full SatsPath demo flow
     Demo,
+}
+
+#[derive(Subcommand)]
+enum WalletCommand {
+    /// Create or load the SatsPath identity key
+    Init,
+    /// Set the alias + public receive methods, then sign and save the profile
+    AddMethods(WalletAddMethodsArgs),
+    /// Add/replace the Lightning Address (re-signs the profile)
+    AddLightning { lightning_address: String },
+    /// Add/replace the on-chain receive address (re-signs the profile)
+    AddOnchain { bitcoin_address: String },
+    /// Add/replace the Ark receive pointer (re-signs the profile)
+    AddArk {
+        #[arg(long)]
+        server: String,
+        #[arg(long)]
+        pubkey: String,
+    },
+    /// Show the wallet's identity, public receive methods, and signature status
+    Show {
+        /// Print full (unmasked) values
+        #[arg(long)]
+        debug: bool,
+    },
+    /// Export the signed profile for peer-to-peer publishing
+    Publish { alias: Option<String> },
+    /// Preview a receive for an amount (no funds moved)
+    Receive {
+        alias: String,
+        amount_sats: u64,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Args)]
+struct WalletAddMethodsArgs {
+    alias: String,
+    #[arg(long)]
+    lightning_address: Option<String>,
+    #[arg(long)]
+    onchain_address: Option<String>,
+    #[arg(long)]
+    ark_server: Option<String>,
+    #[arg(long)]
+    ark_pubkey: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -381,6 +435,32 @@ async fn main() -> Result<()> {
                 commands::cmd_dns_resolve(&args.name, args.json, args.allow_insecure_dns_for_dev)
                     .await?
             }
+        },
+        Command::Wallet { command } => match command {
+            WalletCommand::Init => commands::cmd_wallet_init()?,
+            WalletCommand::AddMethods(args) => commands::cmd_wallet_add_methods(
+                &args.alias,
+                args.lightning_address.as_deref(),
+                args.onchain_address.as_deref(),
+                args.ark_server.as_deref(),
+                args.ark_pubkey.as_deref(),
+            )?,
+            WalletCommand::AddLightning { lightning_address } => {
+                commands::cmd_wallet_add_lightning(&lightning_address)?
+            }
+            WalletCommand::AddOnchain { bitcoin_address } => {
+                commands::cmd_wallet_add_onchain(&bitcoin_address)?
+            }
+            WalletCommand::AddArk { server, pubkey } => {
+                commands::cmd_wallet_add_ark(&server, &pubkey)?
+            }
+            WalletCommand::Show { debug } => commands::cmd_wallet_show(debug)?,
+            WalletCommand::Publish { alias } => commands::cmd_wallet_publish(alias.as_deref())?,
+            WalletCommand::Receive {
+                alias,
+                amount_sats,
+                json,
+            } => commands::cmd_wallet_receive(&alias, amount_sats, json).await?,
         },
         Command::Demo => commands::cmd_demo().await?,
     }

--- a/crates/satspath-cli/src/main.rs
+++ b/crates/satspath-cli/src/main.rs
@@ -177,6 +177,13 @@ enum Command {
         command: WalletCommand,
     },
 
+    /// Launch the minimal, private "Receive" web UI on localhost
+    Web {
+        /// Port to serve on (127.0.0.1 only)
+        #[arg(long, default_value_t = 4848)]
+        port: u16,
+    },
+
     /// Run the full SatsPath demo flow
     Demo,
 }
@@ -462,6 +469,7 @@ async fn main() -> Result<()> {
                 json,
             } => commands::cmd_wallet_receive(&alias, amount_sats, json).await?,
         },
+        Command::Web { port } => commands::cmd_web(port)?,
         Command::Demo => commands::cmd_demo().await?,
     }
 

--- a/crates/satspath-cli/tests/wallet_flow.rs
+++ b/crates/satspath-cli/tests/wallet_flow.rs
@@ -1,0 +1,127 @@
+//! End-to-end `satspath wallet` flow through the real binary:
+//! init → add-methods (signs) → show (verifies) → receive (preview JSON), plus a
+//! tamper test proving a modified saved method breaks signature verification.
+
+use std::path::Path;
+use std::process::Command;
+
+const PUBKEY: &str = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const ONCHAIN: &str = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_satspath")
+}
+
+fn run(dir: &Path, args: &[&str]) -> (String, String, bool) {
+    let out = Command::new(bin())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run satspath binary");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.success(),
+    )
+}
+
+fn add_all(dir: &Path, alias: &str) {
+    assert!(run(dir, &["wallet", "init"]).2, "wallet init failed");
+    let (out, err, ok) = run(
+        dir,
+        &[
+            "wallet",
+            "add-methods",
+            alias,
+            "--lightning-address",
+            alias,
+            "--onchain-address",
+            ONCHAIN,
+            "--ark-server",
+            "https://ark.satspath.dev",
+            "--ark-pubkey",
+            PUBKEY,
+        ],
+    );
+    assert!(ok, "add-methods failed: {err}{out}");
+}
+
+#[test]
+fn wallet_init_add_show_receive_end_to_end() {
+    let dir = tempfile::tempdir().unwrap();
+    let alias = "rodrigodiazgt7@gmail.com";
+    add_all(dir.path(), alias);
+
+    // Identity key + wallet file exist; spending material must not.
+    assert!(dir.path().join(".satspath/wallet.json").exists());
+    let wallet_json = std::fs::read_to_string(dir.path().join(".satspath/wallet.json")).unwrap();
+    for forbidden in [
+        "xprv",
+        "tprv",
+        "seed",
+        "mnemonic",
+        "macaroon",
+        "secret_key",
+        "privkey",
+    ] {
+        assert!(
+            !wallet_json.contains(forbidden),
+            "wallet.json leaked '{forbidden}'"
+        );
+    }
+
+    // show: all public methods preserved + signature valid.
+    let (show, _e, ok) = run(dir.path(), &["wallet", "show"]);
+    assert!(ok);
+    assert!(show.contains("Profile signature: valid"), "show:\n{show}");
+    assert!(show.contains("Lightning"));
+    assert!(show.contains("On-chain"));
+    assert!(show.contains("Ark"));
+
+    // receive: preview-only JSON with the safety warnings.
+    let (json, err, ok) = run(
+        dir.path(),
+        &["wallet", "receive", alias, "100000", "--json"],
+    );
+    assert!(ok, "receive failed: {err}{json}");
+    let v: serde_json::Value = serde_json::from_str(json.trim()).expect("receive must emit JSON");
+    assert_eq!(v["mode"], "preview_only");
+    assert_eq!(v["alias"], alias);
+    assert!(v["qr"].is_string());
+    let warnings = v["warnings"].as_array().unwrap();
+    assert!(warnings.iter().any(|w| w == "No funds moved by SatsPath"));
+    assert!(warnings
+        .iter()
+        .any(|w| w == "Payment execution happens in external wallet"));
+}
+
+#[test]
+fn tampering_with_saved_method_breaks_signature() {
+    let dir = tempfile::tempdir().unwrap();
+    let alias = "rodrigodiazgt7@gmail.com";
+    add_all(dir.path(), alias);
+
+    // Tamper a saved method's address in the registry, without re-signing.
+    let reg_path = dir.path().join(".satspath/registry.json");
+    let mut reg: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&reg_path).unwrap()).unwrap();
+    let profiles = reg["profiles"].as_object_mut().unwrap();
+    let entry = profiles.values_mut().next().unwrap();
+    for method in entry["profile"]["methods"].as_array_mut().unwrap() {
+        if method["type"] == "Onchain" {
+            method["address"] = serde_json::json!("bc1qattackercontrolledaddr00000000000000000");
+        }
+    }
+    std::fs::write(&reg_path, serde_json::to_string_pretty(&reg).unwrap()).unwrap();
+
+    let (show, _e, ok) = run(dir.path(), &["wallet", "show"]);
+    assert!(ok);
+    assert!(
+        show.contains("Profile signature: INVALID"),
+        "tampered method must fail verification:\n{show}"
+    );
+    assert!(
+        show.contains("tampered or stale"),
+        "should show the improved guidance:\n{show}"
+    );
+}

--- a/crates/satspath-core/src/peer_registry.rs
+++ b/crates/satspath-core/src/peer_registry.rs
@@ -207,6 +207,10 @@ impl LocalPeerRegistry {
         std::fs::write(&self.path, json)?;
         Ok(())
     }
+
+    pub fn get_hash(&self, identifier_hash: &str) -> Option<PeerRecord> {
+        self.data.records.get(identifier_hash).cloned()
+    }
 }
 
 impl PeerRegistryBackend for LocalPeerRegistry {

--- a/crates/satspathd/Cargo.toml
+++ b/crates/satspathd/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 hex = { workspace = true }
+qrcode = { version = "0.14", default-features = false }
 satspath-core = { path = "../satspath-core" }
 satspath-router = { path = "../satspath-router" }
 secp256k1 = { workspace = true }

--- a/crates/satspathd/Cargo.toml
+++ b/crates/satspathd/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "satspathd"
+version = "0.1.0"
+edition = "2021"
+description = "Local SatsPath receiver-profile daemon"
+
+[[bin]]
+name = "satspathd"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+hex = { workspace = true }
+satspath-core = { path = "../satspath-core" }
+satspath-router = { path = "../satspath-router" }
+secp256k1 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tiny_http = "0.12"
+tokio = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/satspathd/src/index.html
+++ b/crates/satspathd/src/index.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="referrer" content="no-referrer" />
+<title>SatsPath · Recibir</title>
+<style>
+  :root {
+    --ink: #0a0a0a; --paper: #fff; --hair: #e6e6e6; --muted: #8a8a8a;
+    --serif: "Hoefler Text","Iowan Old Style","Palatino Linotype",Palatino,"Times New Roman",Georgia,serif;
+    --mono: "SF Mono","JetBrains Mono",Menlo,Consolas,"Liberation Mono",monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0; background: var(--paper); color: var(--ink); font-family: var(--serif);
+    -webkit-font-smoothing: antialiased; display: grid; place-items: center; min-height: 100vh;
+  }
+  main { width: 100%; max-width: 420px; padding: 48px 28px; text-align: center; }
+  .brand { font-size: 13px; letter-spacing: 0.42em; text-transform: uppercase; color: var(--muted); margin-bottom: 18px; }
+  h1 { font-weight: 500; font-size: 44px; margin: 0 0 6px; }
+  .tagline { font-style: italic; color: var(--muted); font-size: 16px; margin: 0 0 44px; }
+  button#receive {
+    appearance: none; cursor: pointer; font-family: var(--serif); font-size: 17px;
+    letter-spacing: 0.16em; text-transform: uppercase; color: var(--paper); background: var(--ink);
+    border: 1px solid var(--ink); padding: 18px 46px; transition: background .18s, color .18s, transform .05s;
+  }
+  button#receive:hover { background: var(--paper); color: var(--ink); }
+  button#receive:active { transform: translateY(1px); }
+  button#receive:disabled { opacity: .4; cursor: progress; }
+  .card { margin-top: 40px; border: 1px solid var(--ink); padding: 26px 24px 22px; opacity: 0; transform: translateY(8px); transition: opacity .3s, transform .3s; }
+  .card.show { opacity: 1; transform: none; }
+  .qr { width: 232px; height: 232px; margin: 0 auto 18px; }
+  .qr svg { width: 100%; height: 100%; display: block; }
+  .rail { font-size: 12px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--muted); }
+  .alias { font-size: 18px; margin: 6px 0 16px; }
+  .payload { font-family: var(--mono); font-size: 11px; line-height: 1.6; color: #333; word-break: break-all; border-top: 1px solid var(--hair); padding-top: 14px; margin: 0 0 10px; }
+  .copy { appearance: none; cursor: pointer; font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; background: none; border: 1px solid var(--hair); color: var(--muted); padding: 7px 14px; }
+  .copy:hover { border-color: var(--ink); color: var(--ink); }
+  .err { color: var(--ink); font-style: italic; margin-top: 28px; }
+  footer { margin-top: 40px; font-size: 11px; letter-spacing: 0.06em; color: var(--muted); }
+</style>
+</head>
+<body>
+<main>
+  <div class="brand">SatsPath</div>
+  <h1>Recibir</h1>
+  <p class="tagline">Tu ruta, tu QR. Privado y local.</p>
+  <button id="receive">Recibir</button>
+  <div class="card" id="card" hidden>
+    <div class="qr" id="qr"></div>
+    <div class="rail" id="rail"></div>
+    <div class="alias" id="alias"></div>
+    <p class="payload" id="payload"></p>
+    <button class="copy" id="copy">Copiar</button>
+  </div>
+  <div class="err" id="err" hidden></div>
+  <footer>No mueve fondos · No firma · No transmite · 127.0.0.1</footer>
+</main>
+<script>
+  const $ = (id) => document.getElementById(id);
+  $("receive").addEventListener("click", async () => {
+    const btn = $("receive");
+    btn.disabled = true; $("err").hidden = true;
+    try {
+      const r = await fetch("/v1/receive");
+      const data = await r.json();
+      if (!r.ok || data.error) throw new Error(data.error || "fallo al calcular la ruta");
+      $("qr").innerHTML = data.qr_svg;
+      $("rail").textContent = data.rail;
+      $("alias").textContent = data.alias;
+      $("payload").textContent = data.payload;
+      const card = $("card"); card.hidden = false;
+      requestAnimationFrame(() => card.classList.add("show"));
+      $("copy").onclick = async () => {
+        await navigator.clipboard.writeText(data.payload);
+        $("copy").textContent = "Copiado"; setTimeout(() => ($("copy").textContent = "Copiar"), 1400);
+      };
+    } catch (e) {
+      const err = $("err"); err.textContent = e.message; err.hidden = false;
+    } finally { btn.disabled = false; }
+  });
+</script>
+</body>
+</html>

--- a/crates/satspathd/src/main.rs
+++ b/crates/satspathd/src/main.rs
@@ -12,10 +12,15 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use qrcode::{Color, QrCode};
 use satspath_core::ark::validate_ark_server_url;
+use satspath_core::bip321::{parse_bip321, ParsedBip321Uri};
+use satspath_core::bip353::{resolve_bip353_with, Bip353Resolution, DnssecPolicy, DohTxtResolver};
 use satspath_core::crypto::{
     fingerprint_pubkey, generate_identity_keypair, sign_profile, verify_signed_profile,
 };
+use satspath_core::peer_registry::{LocalPeerRegistry, PeerRecord, PeerRegistryBackend};
+use satspath_core::privacy::mask_identifier;
 use satspath_core::registry::Registry;
 use satspath_core::resolver::ChainResolver;
 use satspath_core::resolvers::{bip353::Bip353Resolver, http::HttpResolver, nostr::NostrResolver};
@@ -24,6 +29,7 @@ use satspath_core::validation::{
     validate_compressed_pubkey, validate_lightning_address,
 };
 use satspath_core::{BitcoinNetwork, PaymentMethod, PaymentProfile, SignedPaymentProfile};
+use satspath_router::QuoteResponse;
 use serde::{Deserialize, Serialize};
 use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 
@@ -51,6 +57,9 @@ struct Cli {
     /// Start the optional Holepunch P2P profile publisher bridge.
     #[arg(long)]
     p2p: bool,
+    /// Do not open the wallet UI in a browser on startup.
+    #[arg(long)]
+    no_open: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -78,6 +87,7 @@ struct AppState {
     home: PathBuf,
     bind: SocketAddr,
     network: String,
+    open_ui: bool,
     p2p: Arc<Mutex<P2pBridge>>,
 }
 
@@ -103,9 +113,51 @@ struct StatusResponse {
 }
 
 #[derive(Debug, Serialize)]
+struct NodeResponse {
+    status: StatusResponse,
+    profile: ProfileResponse,
+    peers: PeersResponse,
+    connections: ConnectionsResponse,
+}
+
+#[derive(Debug, Serialize)]
+struct PeersResponse {
+    active_count: usize,
+    peers: Vec<PeerView>,
+}
+
+#[derive(Debug, Serialize)]
+struct PeerView {
+    identifier_hash: String,
+    display_hint: String,
+    identity_fingerprint: Option<String>,
+    updated_at: i64,
+    expires_at: Option<i64>,
+    active: bool,
+    methods: Vec<String>,
+    record: PeerRecord,
+}
+
+#[derive(Debug, Serialize)]
+struct ConnectionsResponse {
+    active_count: usize,
+    connections: Vec<ConnectionView>,
+}
+
+#[derive(Debug, Serialize)]
+struct ConnectionView {
+    kind: &'static str,
+    status: String,
+    active: bool,
+    detail: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
 struct P2pStatus {
     enabled: bool,
     status: String,
+    active: bool,
+    pid: Option<u32>,
 }
 
 #[derive(Debug, Serialize)]
@@ -137,6 +189,21 @@ struct QuoteRequest {
     amount_sats: u64,
 }
 
+#[derive(Debug, Deserialize)]
+struct PayRequest {
+    recipient: String,
+    amount_sats: u64,
+    #[serde(default)]
+    memo: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DnsResolveRequest {
+    name: String,
+    #[serde(default)]
+    allow_insecure_dns_for_dev: bool,
+}
+
 #[derive(Debug, Serialize)]
 struct ProfileResponse {
     wallet: WalletState,
@@ -149,6 +216,62 @@ struct PreviewResponse<T: Serialize> {
     mode: &'static str,
     warnings: Vec<&'static str>,
     quote: T,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum PayResponse {
+    WalletHandoff {
+        decision_protocol: &'static str,
+        recipient: String,
+        amount_sats: u64,
+        quote: QuoteResponse,
+        payment_payload: String,
+        qr_svg: String,
+        handoff: WalletHandoff,
+        safety: SafetyStatus,
+    },
+    InviteCreated {
+        decision_protocol: &'static str,
+        recipient_hint: String,
+        amount_sats: u64,
+        quote: QuoteResponse,
+        safety: SafetyStatus,
+    },
+    NoRoute {
+        decision_protocol: &'static str,
+        reason: String,
+        quote: QuoteResponse,
+        safety: SafetyStatus,
+    },
+    InvalidSignature {
+        decision_protocol: &'static str,
+        quote: QuoteResponse,
+        safety: SafetyStatus,
+    },
+}
+
+#[derive(Debug, Serialize)]
+struct WalletHandoff {
+    mode: &'static str,
+    instruction: &'static str,
+    opens_external_wallet: bool,
+    daemon_executes_payment: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
+enum DnsResolveResponse {
+    Ok {
+        resolution: Bip353Resolution,
+        parsed: ParsedBip321Uri,
+    },
+    Error {
+        name: String,
+        error: String,
+        strict_mode: bool,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -198,6 +321,7 @@ async fn main() -> Result<()> {
         home,
         bind,
         network,
+        open_ui: !cli.no_open,
         p2p: Arc::new(Mutex::new(bridge)),
     };
 
@@ -207,6 +331,11 @@ async fn main() -> Result<()> {
 
 async fn serve(state: AppState) -> Result<()> {
     let server = Server::http(state.bind).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let url = format!("http://{}/", state.bind);
+    println!("Wallet UI → {url}");
+    if state.open_ui {
+        open_browser(&url);
+    }
     let state = Arc::new(state);
     for request in server.incoming_requests() {
         let state = Arc::clone(&state);
@@ -221,11 +350,19 @@ async fn handle_request(mut request: Request, state: &AppState) -> Result<()> {
     let method = request.method().clone();
     let path = request.url().split('?').next().unwrap_or("/").to_string();
     let response = match (method, path.as_str()) {
+        (Method::Options, _) => empty_response(StatusCode(204)),
+        (Method::Get, "/") => html_response(INDEX_HTML),
+        (Method::Get, "/v1/receive") => json_result(StatusCode(200), receive_view(state)),
         (Method::Get, "/health") => {
             json_response(StatusCode(200), &serde_json::json!({"ok": true}))
         }
+        (Method::Get, "/v1/node") => json_result(StatusCode(200), node_response(state)),
         (Method::Get, "/v1/status") => json_result(StatusCode(200), status_response(state)),
         (Method::Get, "/v1/profile") => json_result(StatusCode(200), profile_response(state)),
+        (Method::Get, "/v1/peers") => json_result(StatusCode(200), peers_response(state)),
+        (Method::Get, "/v1/connections") => {
+            json_result(StatusCode(200), connections_response(state))
+        }
         (Method::Put, "/v1/profile") | (Method::Post, "/v1/profile") => {
             match read_json::<ProfileUpdateRequest>(&mut request)
                 .and_then(|body| update_profile(state, body))
@@ -252,6 +389,14 @@ async fn handle_request(mut request: Request, state: &AppState) -> Result<()> {
             Ok(body) => json_response(StatusCode(200), &quote_response(state, body).await),
             Err(e) => json_error(StatusCode(400), e),
         },
+        (Method::Post, "/v1/pay") => match read_json::<PayRequest>(&mut request) {
+            Ok(body) => json_response(StatusCode(200), &pay_response(state, body).await),
+            Err(e) => json_error(StatusCode(400), e),
+        },
+        (Method::Post, "/v1/dns/resolve") => match read_json::<DnsResolveRequest>(&mut request) {
+            Ok(body) => json_response(StatusCode(200), &dns_resolve_response(body).await),
+            Err(e) => json_error(StatusCode(400), e),
+        },
         (Method::Post, "/v1/preview") => match read_json::<QuoteRequest>(&mut request) {
             Ok(body) => {
                 let quote = quote_response(state, body).await;
@@ -275,7 +420,7 @@ async fn handle_request(mut request: Request, state: &AppState) -> Result<()> {
 fn update_profile(state: &AppState, body: ProfileUpdateRequest) -> Result<ProfileResponse> {
     let mut wallet = load_or_create_identity(&state.home)?;
     if let Some(alias) = &body.alias {
-        assert_no_private_material(&alias)?;
+        assert_no_private_material(alias)?;
         wallet.alias = Some(alias.clone());
     }
     apply_method_updates(&mut wallet, &state.network, body, true)?;
@@ -377,6 +522,110 @@ async fn quote_response(state: &AppState, body: QuoteRequest) -> satspath_router
     satspath_router::quote_with_resolver(&resolver, &body.recipient, body.amount_sats).await
 }
 
+async fn pay_response(state: &AppState, body: PayRequest) -> PayResponse {
+    if let Err(e) = validate_amount_sats(body.amount_sats) {
+        let quote = QuoteResponse::NoRoute {
+            reason: e.to_string(),
+        };
+        return PayResponse::NoRoute {
+            decision_protocol: "satspathd.v1",
+            reason: e.to_string(),
+            quote,
+            safety: safety_status(),
+        };
+    }
+    if let Some(memo) = &body.memo {
+        if let Err(e) = assert_no_private_material(memo) {
+            let quote = QuoteResponse::NoRoute {
+                reason: e.to_string(),
+            };
+            return PayResponse::NoRoute {
+                decision_protocol: "satspathd.v1",
+                reason: e.to_string(),
+                quote,
+                safety: safety_status(),
+            };
+        }
+    }
+
+    let quote = quote_response(
+        state,
+        QuoteRequest {
+            recipient: body.recipient.clone(),
+            amount_sats: body.amount_sats,
+        },
+    )
+    .await;
+
+    match quote.clone() {
+        QuoteResponse::Ok { qr, .. } => match qr_svg(&qr) {
+            Ok(qr_svg) => PayResponse::WalletHandoff {
+                decision_protocol: "satspathd.v1",
+                recipient: body.recipient,
+                amount_sats: body.amount_sats,
+                quote,
+                payment_payload: qr,
+                qr_svg,
+                handoff: WalletHandoff {
+                    mode: "external_wallet",
+                    instruction: "Open or scan payment_payload with a wallet you control.",
+                    opens_external_wallet: true,
+                    daemon_executes_payment: false,
+                },
+                safety: safety_status(),
+            },
+            Err(e) => PayResponse::NoRoute {
+                decision_protocol: "satspathd.v1",
+                reason: e.to_string(),
+                quote,
+                safety: safety_status(),
+            },
+        },
+        QuoteResponse::NotRegistered { .. } => PayResponse::InviteCreated {
+            decision_protocol: "satspathd.v1",
+            recipient_hint: mask_identifier(&body.recipient),
+            amount_sats: body.amount_sats,
+            quote,
+            safety: safety_status(),
+        },
+        QuoteResponse::NoRoute { reason } => PayResponse::NoRoute {
+            decision_protocol: "satspathd.v1",
+            reason,
+            quote,
+            safety: safety_status(),
+        },
+        QuoteResponse::InvalidSignature { .. } => PayResponse::InvalidSignature {
+            decision_protocol: "satspathd.v1",
+            quote,
+            safety: safety_status(),
+        },
+    }
+}
+
+async fn dns_resolve_response(body: DnsResolveRequest) -> DnsResolveResponse {
+    let policy = if body.allow_insecure_dns_for_dev {
+        DnssecPolicy::DevInsecure
+    } else {
+        DnssecPolicy::Strict
+    };
+    let resolver = DohTxtResolver::new();
+    match resolve_bip353_with(&resolver, &body.name, policy, now()).await {
+        Ok(resolution) => match parse_bip321(&resolution.bitcoin_uri) {
+            Ok(parsed) => DnsResolveResponse::Ok { resolution, parsed },
+            Err(e) => DnsResolveResponse::Error {
+                name: body.name,
+                error: e.to_string(),
+                strict_mode: policy == DnssecPolicy::Strict,
+            },
+        },
+        Err(e) => DnsResolveResponse::Error {
+            name: body.name,
+            error: e.to_string(),
+            strict_mode: policy == DnssecPolicy::Strict,
+        },
+    }
+}
+
 fn profile_response(state: &AppState) -> Result<ProfileResponse> {
     let wallet = load_wallet(&state.home)?;
     let signed_profile = match wallet.alias.as_deref() {
@@ -396,6 +645,91 @@ fn profile_response(state: &AppState) -> Result<ProfileResponse> {
     })
 }
 
+fn node_response(state: &AppState) -> Result<NodeResponse> {
+    Ok(NodeResponse {
+        status: status_response(state)?,
+        profile: profile_response(state)?,
+        peers: peers_response(state)?,
+        connections: connections_response(state)?,
+    })
+}
+
+fn peers_response(state: &AppState) -> Result<PeersResponse> {
+    let registry = LocalPeerRegistry::open(&state.home)?;
+    let mut peers = Vec::new();
+    for hash in registry.list_hashes()? {
+        if let Some(record) = registry.get_hash(&hash) {
+            peers.push(peer_view(record));
+        }
+    }
+    peers.sort_by_key(|b| std::cmp::Reverse(b.updated_at));
+    let active_count = peers.iter().filter(|peer| peer.active).count();
+    Ok(PeersResponse {
+        active_count,
+        peers,
+    })
+}
+
+fn peer_view(record: PeerRecord) -> PeerView {
+    let active = record
+        .expires_at
+        .map(|expires_at| expires_at > now())
+        .unwrap_or(true);
+    let identity_fingerprint = fingerprint_pubkey(&record.identity_pubkey).ok();
+    let mut methods = Vec::new();
+    if record.pointers.lightning.is_some() {
+        methods.push("Lightning".into());
+    }
+    if record.pointers.onchain.is_some() {
+        methods.push("Onchain".into());
+    }
+    if record.pointers.ark.is_some() {
+        methods.push("Ark".into());
+    }
+    PeerView {
+        identifier_hash: record.identifier_hash.clone(),
+        display_hint: record.display_hint.clone(),
+        identity_fingerprint,
+        updated_at: record.updated_at,
+        expires_at: record.expires_at,
+        active,
+        methods,
+        record,
+    }
+}
+
+fn connections_response(state: &AppState) -> Result<ConnectionsResponse> {
+    let peers = peers_response(state)?;
+    let p2p = p2p_status(state);
+    let mut connections = Vec::new();
+    connections.push(ConnectionView {
+        kind: "p2p_bridge",
+        status: p2p.status.clone(),
+        active: p2p.active,
+        detail: p2p.pid.map(|pid| format!("pid:{pid}")),
+    });
+    connections.push(ConnectionView {
+        kind: "peer_registry",
+        status: format!("{} active peer(s)", peers.active_count),
+        active: peers.active_count > 0,
+        detail: Some(
+            state
+                .home
+                .join("peers/registry.local.json")
+                .display()
+                .to_string(),
+        ),
+    });
+    let active_count = connections
+        .iter()
+        .filter(|connection| connection.active)
+        .count();
+    Ok(ConnectionsResponse {
+        active_count,
+        connections,
+    })
+}
+
 fn status_response(state: &AppState) -> Result<StatusResponse> {
     let wallet = load_wallet(&state.home)?;
     let methods = build_methods(&wallet, &state.network)
@@ -407,7 +741,7 @@ fn status_response(state: &AppState) -> Result<StatusResponse> {
         .as_deref()
         .map(fingerprint_pubkey)
         .transpose()?;
-    let p2p = state.p2p.lock().expect("p2p mutex poisoned");
+    let p2p = p2p_status(state);
     Ok(StatusResponse {
         daemon: "satspathd",
         version: env!("CARGO_PKG_VERSION"),
@@ -420,16 +754,52 @@ fn status_response(state: &AppState) -> Result<StatusResponse> {
         methods,
         p2p: P2pStatus {
             enabled: p2p.enabled,
-            status: p2p.status.clone(),
+            status: p2p.status,
+            active: p2p.active,
+            pid: p2p.pid,
         },
-        safety: SafetyStatus {
-            moves_funds: false,
-            signs_bitcoin_transactions: false,
-            broadcasts_transactions: false,
-            stores_wallet_seeds_or_spending_keys: false,
-            manages_signed_profiles: true,
-        },
+        safety: safety_status(),
     })
+}
+
+fn p2p_status(state: &AppState) -> P2pStatus {
+    let mut p2p = state.p2p.lock().expect("p2p mutex poisoned");
+    let mut active = false;
+    let mut pid = None;
+    if let Some(child) = p2p.child.as_mut() {
+        pid = Some(child.id());
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                p2p.status = format!("exited: {status}");
+                p2p.child = None;
+            }
+            Ok(None) => {
+                active = true;
+                if p2p.status == "disabled" {
+                    p2p.status = "started".into();
+                }
+            }
+            Err(e) => {
+                p2p.status = format!("unknown: {e}");
+            }
+        }
+    }
+    P2pStatus {
+        enabled: p2p.enabled,
+        status: p2p.status.clone(),
+        active,
+        pid,
+    }
+}
+
+fn safety_status() -> SafetyStatus {
+    SafetyStatus {
+        moves_funds: false,
+        signs_bitcoin_transactions: false,
+        broadcasts_transactions: false,
+        stores_wallet_seeds_or_spending_keys: false,
+        manages_signed_profiles: true,
+    }
 }
 
 fn resolver_chain(home: &Path) -> ChainResolver {
@@ -631,6 +1001,123 @@ fn json_result<T: Serialize>(
     }
 }
 
+// ─── Receive wallet UI ─────────────────────────────────────────────────────────
+
+const INDEX_HTML: &str = include_str!("index.html");
+
+#[derive(Debug, Serialize)]
+struct ReceiveView {
+    /// Masked alias, e.g. `r***@gmail.com` — the raw identifier is never exposed.
+    alias: String,
+    rail: String,
+    payload: String,
+    qr_svg: String,
+}
+
+/// Compute the wallet owner's preferred receive QR, entirely locally. Prefers
+/// Lightning → on-chain → Ark. Returns a reusable (amount-less) receive pointer.
+fn receive_view(state: &AppState) -> Result<ReceiveView> {
+    let wallet = load_wallet(&state.home)?;
+    let alias = wallet
+        .alias
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("no profile yet — set one via POST /v1/profile"))?;
+    let methods = build_methods(&wallet, &state.network);
+    let method = methods
+        .iter()
+        .find(|m| matches!(m, PaymentMethod::Lightning { .. }))
+        .or_else(|| {
+            methods
+                .iter()
+                .find(|m| matches!(m, PaymentMethod::Onchain { .. }))
+        })
+        .or_else(|| {
+            methods
+                .iter()
+                .find(|m| matches!(m, PaymentMethod::Ark { .. }))
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!("no receive methods — add one via POST /v1/profile/methods")
+        })?;
+    let payload = receive_payload_for(method)?;
+    Ok(ReceiveView {
+        alias: mask_identifier(&alias),
+        rail: method.method_name().to_string(),
+        qr_svg: qr_svg(&payload)?,
+        payload,
+    })
+}
+
+/// A public, amount-less receive pointer for a method.
+fn receive_payload_for(method: &PaymentMethod) -> Result<String> {
+    let payload = match method {
+        PaymentMethod::Lightning {
+            lightning_address: Some(addr),
+            ..
+        } => addr.clone(),
+        PaymentMethod::Lightning {
+            lnurl: Some(url), ..
+        } => url.clone(),
+        PaymentMethod::Onchain { address, .. } => format!("bitcoin:{address}"),
+        PaymentMethod::Ark { server, pubkey, .. } => {
+            format!("satspath:ark?server={server}&pubkey={pubkey}")
+        }
+        _ => anyhow::bail!("selected method has no receive pointer"),
+    };
+    assert_no_private_material(&payload)?;
+    Ok(payload)
+}
+
+/// Render a payload as a self-contained black-and-white SVG QR.
+fn qr_svg(data: &str) -> Result<String> {
+    let code = QrCode::new(data.as_bytes()).map_err(|e| anyhow::anyhow!("QR encode: {e}"))?;
+    let width = code.width();
+    let colors = code.to_colors();
+    let quiet = 4usize;
+    let size = width + quiet * 2;
+    let mut rects = String::new();
+    for y in 0..width {
+        for x in 0..width {
+            if colors[y * width + x] == Color::Dark {
+                rects.push_str(&format!(
+                    "<rect x='{}' y='{}' width='1' height='1'/>",
+                    x + quiet,
+                    y + quiet
+                ));
+            }
+        }
+    }
+    Ok(format!(
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 {size} {size}' \
+         shape-rendering='crispEdges'><rect width='100%' height='100%' fill='#fff'/>\
+         <g fill='#000'>{rects}</g></svg>"
+    ))
+}
+
+fn html_response(body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let header = Header::from_bytes(&b"Content-Type"[..], &b"text/html; charset=utf-8"[..])
+        .expect("static header");
+    Response::from_data(body.as_bytes().to_vec())
+        .with_status_code(StatusCode(200))
+        .with_header(header)
+        .with_header(cors_origin_header())
+}
+
+/// Best-effort open of the default browser. Never fails the daemon.
+fn open_browser(url: &str) {
+    #[cfg(target_os = "macos")]
+    let (cmd, args): (&str, Vec<&str>) = ("open", vec![url]);
+    #[cfg(target_os = "linux")]
+    let (cmd, args): (&str, Vec<&str>) = ("xdg-open", vec![url]);
+    #[cfg(target_os = "windows")]
+    let (cmd, args): (&str, Vec<&str>) = ("cmd", vec!["/C", "start", "", url]);
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    let (cmd, args): (&str, Vec<&str>) = ("", vec![]);
+    if !cmd.is_empty() {
+        let _ = Command::new(cmd).args(args).spawn();
+    }
+}
+
 fn json_response<T: Serialize>(
     status: StatusCode,
     value: &T,
@@ -640,6 +1127,17 @@ fn json_response<T: Serialize>(
     Response::from_data(body)
         .with_status_code(status)
         .with_header(json_header())
+        .with_header(cors_origin_header())
+        .with_header(cors_methods_header())
+        .with_header(cors_headers_header())
+}
+
+fn empty_response(status: StatusCode) -> Response<std::io::Cursor<Vec<u8>>> {
+    Response::from_data(Vec::new())
+        .with_status_code(status)
+        .with_header(cors_origin_header())
+        .with_header(cors_methods_header())
+        .with_header(cors_headers_header())
 }
 
 fn json_error(status: StatusCode, error: anyhow::Error) -> Response<std::io::Cursor<Vec<u8>>> {
@@ -653,6 +1151,23 @@ fn json_error(status: StatusCode, error: anyhow::Error) -> Response<std::io::Cur
 
 fn json_header() -> Header {
     Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).expect("valid static header")
+}
+
+fn cors_origin_header() -> Header {
+    Header::from_bytes(&b"Access-Control-Allow-Origin"[..], &b"*"[..]).expect("valid static header")
+}
+
+fn cors_methods_header() -> Header {
+    Header::from_bytes(
+        &b"Access-Control-Allow-Methods"[..],
+        &b"GET, POST, PUT, OPTIONS"[..],
+    )
+    .expect("valid static header")
+}
+
+fn cors_headers_header() -> Header {
+    Header::from_bytes(&b"Access-Control-Allow-Headers"[..], &b"Content-Type"[..])
+        .expect("valid static header")
 }
 
 fn safety_warnings() -> Vec<&'static str> {
@@ -669,10 +1184,17 @@ fn wallet_path(home: &Path) -> PathBuf {
 }
 
 fn default_home() -> PathBuf {
+    // Prefer a `.satspath/` in the current directory (e.g. a wallet created with
+    // `satspath wallet ...`) so the daemon serves the same profile seamlessly;
+    // otherwise fall back to the per-user `~/.satspath`.
+    let local = PathBuf::from(".satspath");
+    if local.is_dir() {
+        return local;
+    }
     if let Some(home) = std::env::var_os("HOME") {
         PathBuf::from(home).join(".satspath")
     } else {
-        PathBuf::from(".satspath")
+        local
     }
 }
 

--- a/crates/satspathd/src/main.rs
+++ b/crates/satspathd/src/main.rs
@@ -1,0 +1,737 @@
+//! `satspathd` is a local receiver-profile daemon.
+//!
+//! It manages SatsPath profile identity and public receive pointers only. It
+//! does not move funds, sign Bitcoin transactions, broadcast transactions, or
+//! store Bitcoin wallet seeds/spending keys.
+
+use std::fs;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use satspath_core::ark::validate_ark_server_url;
+use satspath_core::crypto::{
+    fingerprint_pubkey, generate_identity_keypair, sign_profile, verify_signed_profile,
+};
+use satspath_core::registry::Registry;
+use satspath_core::resolver::ChainResolver;
+use satspath_core::resolvers::{bip353::Bip353Resolver, http::HttpResolver, nostr::NostrResolver};
+use satspath_core::validation::{
+    assert_no_private_material, validate_amount_sats, validate_bitcoin_address,
+    validate_compressed_pubkey, validate_lightning_address,
+};
+use satspath_core::{BitcoinNetwork, PaymentMethod, PaymentProfile, SignedPaymentProfile};
+use serde::{Deserialize, Serialize};
+use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
+
+const DEFAULT_BIND: &str = "127.0.0.1:9737";
+const DEFAULT_NETWORK: &str = "devnet";
+const WALLET_FILE: &str = "wallet.json";
+const IDENTITY_SUBDIR: &str = "identity";
+
+#[derive(Parser)]
+#[command(
+    name = "satspathd",
+    about = "Local SatsPath receiver-profile daemon",
+    version = "0.1.0"
+)]
+struct Cli {
+    /// HTTP bind address. Defaults to SATSPATHD_BIND or 127.0.0.1:9737.
+    #[arg(long)]
+    bind: Option<String>,
+    /// SatsPath network label. Defaults to SATSPATH_NETWORK or devnet.
+    #[arg(long)]
+    network: Option<String>,
+    /// SatsPath home directory. Defaults to SATSPATH_HOME or ~/.satspath.
+    #[arg(long)]
+    home: Option<PathBuf>,
+    /// Start the optional Holepunch P2P profile publisher bridge.
+    #[arg(long)]
+    p2p: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct WalletState {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    alias: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    identity_pubkey: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lightning_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    onchain_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ark_server: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ark_pubkey: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    created_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    updated_at: Option<i64>,
+}
+
+#[derive(Clone)]
+struct AppState {
+    home: PathBuf,
+    bind: SocketAddr,
+    network: String,
+    p2p: Arc<Mutex<P2pBridge>>,
+}
+
+struct P2pBridge {
+    enabled: bool,
+    status: String,
+    child: Option<Child>,
+}
+
+#[derive(Debug, Serialize)]
+struct StatusResponse {
+    daemon: &'static str,
+    version: &'static str,
+    bind: String,
+    network: String,
+    home: String,
+    wallet_initialized: bool,
+    alias: Option<String>,
+    identity_fingerprint: Option<String>,
+    methods: Vec<String>,
+    p2p: P2pStatus,
+    safety: SafetyStatus,
+}
+
+#[derive(Debug, Serialize)]
+struct P2pStatus {
+    enabled: bool,
+    status: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SafetyStatus {
+    moves_funds: bool,
+    signs_bitcoin_transactions: bool,
+    broadcasts_transactions: bool,
+    stores_wallet_seeds_or_spending_keys: bool,
+    manages_signed_profiles: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProfileUpdateRequest {
+    alias: Option<String>,
+    lightning_address: Option<String>,
+    onchain_address: Option<String>,
+    ark_server: Option<String>,
+    ark_pubkey: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AliasRequest {
+    alias: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct QuoteRequest {
+    recipient: String,
+    amount_sats: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct ProfileResponse {
+    wallet: WalletState,
+    signed_profile: Option<SignedPaymentProfile>,
+    signature_valid: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+struct PreviewResponse<T: Serialize> {
+    mode: &'static str,
+    warnings: Vec<&'static str>,
+    quote: T,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let bind = cli
+        .bind
+        .or_else(|| std::env::var("SATSPATHD_BIND").ok())
+        .unwrap_or_else(|| DEFAULT_BIND.to_string())
+        .parse::<SocketAddr>()
+        .context("invalid bind address")?;
+    let network = cli
+        .network
+        .or_else(|| std::env::var("SATSPATH_NETWORK").ok())
+        .unwrap_or_else(|| DEFAULT_NETWORK.to_string());
+    let home = cli
+        .home
+        .or_else(|| std::env::var_os("SATSPATH_HOME").map(PathBuf::from))
+        .unwrap_or_else(default_home);
+    let p2p_requested = cli.p2p || env_truthy("SATSPATHD_P2P");
+
+    fs::create_dir_all(&home).context("creating SATSPATH_HOME")?;
+    let wallet = load_or_create_identity(&home)?;
+    let mut bridge = P2pBridge {
+        enabled: p2p_requested,
+        status: "disabled".into(),
+        child: None,
+    };
+    if p2p_requested {
+        match start_p2p_bridge(&home, &wallet) {
+            Ok((status, child)) => {
+                bridge.status = status;
+                bridge.child = Some(child);
+            }
+            Err(e) => {
+                bridge.status = format!("inactive: {e}");
+            }
+        }
+    }
+
+    let state = AppState {
+        home,
+        bind,
+        network,
+        p2p: Arc::new(Mutex::new(bridge)),
+    };
+
+    print_startup_status(&state)?;
+    serve(state).await
+}
+
+async fn serve(state: AppState) -> Result<()> {
+    let server = Server::http(state.bind).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let state = Arc::new(state);
+    for request in server.incoming_requests() {
+        let state = Arc::clone(&state);
+        if let Err(e) = handle_request(request, &state).await {
+            eprintln!("request error: {e}");
+        }
+    }
+    Ok(())
+}
+
+async fn handle_request(mut request: Request, state: &AppState) -> Result<()> {
+    let method = request.method().clone();
+    let path = request.url().split('?').next().unwrap_or("/").to_string();
+    let response = match (method, path.as_str()) {
+        (Method::Get, "/health") => {
+            json_response(StatusCode(200), &serde_json::json!({"ok": true}))
+        }
+        (Method::Get, "/v1/status") => json_result(StatusCode(200), status_response(state)),
+        (Method::Get, "/v1/profile") => json_result(StatusCode(200), profile_response(state)),
+        (Method::Put, "/v1/profile") | (Method::Post, "/v1/profile") => {
+            match read_json::<ProfileUpdateRequest>(&mut request)
+                .and_then(|body| update_profile(state, body))
+            {
+                Ok(resp) => json_response(StatusCode(200), &resp),
+                Err(e) => json_error(StatusCode(400), e),
+            }
+        }
+        (Method::Post, "/v1/profile/methods") => {
+            match read_json::<ProfileUpdateRequest>(&mut request)
+                .and_then(|body| update_profile_methods(state, body))
+            {
+                Ok(resp) => json_response(StatusCode(200), &resp),
+                Err(e) => json_error(StatusCode(400), e),
+            }
+        }
+        (Method::Post, "/v1/resolve") => match read_json::<AliasRequest>(&mut request)
+            .and_then(|body| resolve_profile(state, &body.alias))
+        {
+            Ok(profile) => json_response(StatusCode(200), &profile),
+            Err(e) => json_error(StatusCode(404), e),
+        },
+        (Method::Post, "/v1/quote") => match read_json::<QuoteRequest>(&mut request) {
+            Ok(body) => json_response(StatusCode(200), &quote_response(state, body).await),
+            Err(e) => json_error(StatusCode(400), e),
+        },
+        (Method::Post, "/v1/preview") => match read_json::<QuoteRequest>(&mut request) {
+            Ok(body) => {
+                let quote = quote_response(state, body).await;
+                json_response(
+                    StatusCode(200),
+                    &PreviewResponse {
+                        mode: "preview_only",
+                        warnings: safety_warnings(),
+                        quote,
+                    },
+                )
+            }
+            Err(e) => json_error(StatusCode(400), e),
+        },
+        _ => json_error(StatusCode(404), anyhow::anyhow!("endpoint not found")),
+    };
+    request.respond(response)?;
+    Ok(())
+}
+
+fn update_profile(state: &AppState, body: ProfileUpdateRequest) -> Result<ProfileResponse> {
+    let mut wallet = load_or_create_identity(&state.home)?;
+    if let Some(alias) = &body.alias {
+        assert_no_private_material(&alias)?;
+        wallet.alias = Some(alias.clone());
+    }
+    apply_method_updates(&mut wallet, &state.network, body, true)?;
+    sign_and_store(&state.home, &mut wallet, &state.network)?;
+    save_wallet(&state.home, &wallet)?;
+    profile_response(state)
+}
+
+fn update_profile_methods(state: &AppState, body: ProfileUpdateRequest) -> Result<ProfileResponse> {
+    let mut wallet = load_or_create_identity(&state.home)?;
+    if wallet.alias.is_none() {
+        anyhow::bail!("set alias first with PUT /v1/profile");
+    }
+    apply_method_updates(&mut wallet, &state.network, body, false)?;
+    sign_and_store(&state.home, &mut wallet, &state.network)?;
+    save_wallet(&state.home, &wallet)?;
+    profile_response(state)
+}
+
+fn apply_method_updates(
+    wallet: &mut WalletState,
+    network: &str,
+    body: ProfileUpdateRequest,
+    allow_empty: bool,
+) -> Result<()> {
+    let has_method = body.lightning_address.is_some()
+        || body.onchain_address.is_some()
+        || body.ark_server.is_some()
+        || body.ark_pubkey.is_some();
+    if !allow_empty && !has_method {
+        anyhow::bail!("provide at least one receive method");
+    }
+
+    if let Some(addr) = body.lightning_address {
+        validate_lightning_address(&addr)?;
+        wallet.lightning_address = Some(addr);
+    }
+    if let Some(addr) = body.onchain_address {
+        validate_bitcoin_address(&addr, bitcoin_network(network))?;
+        wallet.onchain_address = Some(addr);
+    }
+    match (body.ark_server, body.ark_pubkey) {
+        (Some(server), Some(pubkey)) => {
+            validate_ark_server_url(&server)?;
+            validate_compressed_pubkey(&pubkey)?;
+            wallet.ark_server = Some(server);
+            wallet.ark_pubkey = Some(pubkey);
+        }
+        (None, None) => {}
+        _ => anyhow::bail!("ark_server and ark_pubkey must be provided together"),
+    }
+    wallet.updated_at = Some(now());
+    Ok(())
+}
+
+fn sign_and_store(home: &Path, wallet: &mut WalletState, network: &str) -> Result<()> {
+    let alias = wallet
+        .alias
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("profile alias is required"))?;
+    let identity_pubkey = wallet
+        .identity_pubkey
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("identity is not initialized"))?;
+    let methods = build_methods(wallet, network);
+    if methods.is_empty() {
+        anyhow::bail!("profile needs at least one public receive method");
+    }
+
+    let secret = load_identity_key(home, &identity_pubkey)?;
+    let profile = PaymentProfile {
+        alias,
+        identity_pubkey,
+        methods,
+        updated_at: now(),
+        expires_at: None,
+        method_verifications: Vec::new(),
+    };
+    let signed = sign_profile(profile, &secret)?;
+    Registry::open(home)?.update_profile(signed)?;
+    Ok(())
+}
+
+fn resolve_profile(state: &AppState, alias: &str) -> Result<SignedPaymentProfile> {
+    let signed = Registry::open(&state.home)?.resolve_alias(alias)?.clone();
+    if !verify_signed_profile(&signed)? {
+        anyhow::bail!("stored profile signature is invalid");
+    }
+    Ok(signed)
+}
+
+async fn quote_response(state: &AppState, body: QuoteRequest) -> satspath_router::QuoteResponse {
+    if let Err(e) = validate_amount_sats(body.amount_sats) {
+        return satspath_router::QuoteResponse::NoRoute {
+            reason: e.to_string(),
+        };
+    }
+    let resolver = resolver_chain(&state.home);
+    satspath_router::quote_with_resolver(&resolver, &body.recipient, body.amount_sats).await
+}
+
+fn profile_response(state: &AppState) -> Result<ProfileResponse> {
+    let wallet = load_wallet(&state.home)?;
+    let signed_profile = match wallet.alias.as_deref() {
+        Some(alias) => Registry::open(&state.home)
+            .and_then(|registry| registry.resolve_alias(alias).cloned())
+            .ok(),
+        None => None,
+    };
+    let signature_valid = signed_profile
+        .as_ref()
+        .map(verify_signed_profile)
+        .transpose()?;
+    Ok(ProfileResponse {
+        wallet,
+        signed_profile,
+        signature_valid,
+    })
+}
+
+fn status_response(state: &AppState) -> Result<StatusResponse> {
+    let wallet = load_wallet(&state.home)?;
+    let methods = build_methods(&wallet, &state.network)
+        .iter()
+        .map(|method| method.method_name().to_string())
+        .collect();
+    let identity_fingerprint = wallet
+        .identity_pubkey
+        .as_deref()
+        .map(fingerprint_pubkey)
+        .transpose()?;
+    let p2p = state.p2p.lock().expect("p2p mutex poisoned");
+    Ok(StatusResponse {
+        daemon: "satspathd",
+        version: env!("CARGO_PKG_VERSION"),
+        bind: state.bind.to_string(),
+        network: state.network.clone(),
+        home: state.home.display().to_string(),
+        wallet_initialized: wallet.identity_pubkey.is_some(),
+        alias: wallet.alias,
+        identity_fingerprint,
+        methods,
+        p2p: P2pStatus {
+            enabled: p2p.enabled,
+            status: p2p.status.clone(),
+        },
+        safety: SafetyStatus {
+            moves_funds: false,
+            signs_bitcoin_transactions: false,
+            broadcasts_transactions: false,
+            stores_wallet_seeds_or_spending_keys: false,
+            manages_signed_profiles: true,
+        },
+    })
+}
+
+fn resolver_chain(home: &Path) -> ChainResolver {
+    let mut chain = ChainResolver::new();
+    if let Ok(registry) = Registry::open(home) {
+        chain = chain.push(registry);
+    }
+    chain
+        .push(Bip353Resolver::new())
+        .push(HttpResolver::new())
+        .push(NostrResolver)
+}
+
+fn build_methods(wallet: &WalletState, network: &str) -> Vec<PaymentMethod> {
+    let mut methods = Vec::new();
+    if let Some(addr) = &wallet.lightning_address {
+        methods.push(PaymentMethod::Lightning {
+            label: "Lightning Address".into(),
+            lightning_address: Some(addr.clone()),
+            lnurl: None,
+            bolt12: None,
+            receiver_pubkey: None,
+        });
+    }
+    if let Some(addr) = &wallet.onchain_address {
+        methods.push(PaymentMethod::Onchain {
+            label: format!("Bitcoin ({})", network),
+            network: bitcoin_network(network),
+            address: addr.clone(),
+            pubkey_hint: None,
+            descriptor_hint: None,
+        });
+    }
+    if let (Some(server), Some(pubkey)) = (&wallet.ark_server, &wallet.ark_pubkey) {
+        methods.push(PaymentMethod::Ark {
+            label: "Ark".into(),
+            server: server.clone(),
+            pubkey: pubkey.clone(),
+            vtxo_pointer: None,
+            proof: None,
+            expires_at: None,
+        });
+    }
+    methods
+}
+
+fn load_or_create_identity(home: &Path) -> Result<WalletState> {
+    let mut wallet = load_wallet(home)?;
+    if wallet.identity_pubkey.is_some() {
+        return Ok(wallet);
+    }
+    let kp = generate_identity_keypair();
+    let pubkey = hex::encode(kp.public_key.serialize());
+    save_identity_key(home, &kp.secret_key)?;
+    wallet.identity_pubkey = Some(pubkey);
+    wallet.created_at = Some(now());
+    wallet.updated_at = Some(now());
+    save_wallet(home, &wallet)?;
+    Ok(wallet)
+}
+
+fn load_wallet(home: &Path) -> Result<WalletState> {
+    let path = wallet_path(home);
+    if !path.exists() {
+        return Ok(WalletState::default());
+    }
+    let raw = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&raw)?)
+}
+
+fn save_wallet(home: &Path, wallet: &WalletState) -> Result<()> {
+    fs::create_dir_all(home)?;
+    let json = serde_json::to_string_pretty(wallet)?;
+    assert_no_private_material(&json)?;
+    fs::write(wallet_path(home), json)?;
+    Ok(())
+}
+
+fn save_identity_key(home: &Path, secret_key: &secp256k1::SecretKey) -> Result<PathBuf> {
+    let secp = secp256k1::Secp256k1::new();
+    let pubkey = secp256k1::PublicKey::from_secret_key(&secp, secret_key);
+    let dir = home.join(IDENTITY_SUBDIR);
+    fs::create_dir_all(&dir)?;
+    let path = dir.join(format!("{}.key", hex::encode(pubkey.serialize())));
+    fs::write(&path, hex::encode(secret_key.secret_bytes()))?;
+    set_owner_only(&path)?;
+    Ok(path)
+}
+
+fn load_identity_key(home: &Path, identity_pubkey: &str) -> Result<secp256k1::SecretKey> {
+    let path = home
+        .join(IDENTITY_SUBDIR)
+        .join(format!("{identity_pubkey}.key"));
+    let hex_secret = fs::read_to_string(&path)
+        .with_context(|| format!("reading identity key at {}", path.display()))?;
+    let bytes = hex::decode(hex_secret.trim())?;
+    let secret = secp256k1::SecretKey::from_slice(&bytes)?;
+    let secp = secp256k1::Secp256k1::new();
+    let actual = secp256k1::PublicKey::from_secret_key(&secp, &secret);
+    if hex::encode(actual.serialize()) != identity_pubkey {
+        anyhow::bail!("identity key file does not match wallet identity pubkey");
+    }
+    Ok(secret)
+}
+
+#[cfg(unix)]
+fn set_owner_only(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path)?.permissions();
+    perms.set_mode(0o600);
+    fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_owner_only(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn start_p2p_bridge(home: &Path, wallet: &WalletState) -> Result<(String, Child)> {
+    let alias = wallet
+        .alias
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("no local alias/profile yet"))?;
+    let signed = Registry::open(home)?.resolve_alias(alias)?.clone();
+    if !verify_signed_profile(&signed)? {
+        anyhow::bail!("refusing to bridge invalid signed profile");
+    }
+    let out_path = home.join(format!("{}-profile.json", sanitize(alias)));
+    fs::write(&out_path, serde_json::to_string_pretty(&signed)?)?;
+
+    let repo_root = std::env::current_dir()?;
+    let sdk_dir = repo_root.join("sdk").join("satspath-p2p");
+    let script = sdk_dir.join("examples").join("publish.mjs");
+    if !script.exists() {
+        anyhow::bail!("P2P SDK publish script not found at {}", script.display());
+    }
+    let child = Command::new("node")
+        .arg("examples/publish.mjs")
+        .arg(&out_path)
+        .current_dir(&sdk_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("starting Node Holepunch bridge")?;
+
+    // The child is intentionally detached from request handling. If it exits,
+    // status remains "started"; users can see process logs by running the SDK
+    // directly while this bridge is still optional.
+    Ok((format!("started: publishing {alias}"), child))
+}
+
+fn print_startup_status(state: &AppState) -> Result<()> {
+    let status = status_response(state)?;
+    println!("satspathd node starting");
+    println!("  bind: {}", status.bind);
+    println!("  network: {}", status.network);
+    println!("  home: {}", status.home);
+    println!(
+        "  identity: {}",
+        status
+            .identity_fingerprint
+            .as_deref()
+            .unwrap_or("(not initialized)")
+    );
+    println!(
+        "  alias: {}",
+        status.alias.as_deref().unwrap_or("(not configured)")
+    );
+    println!(
+        "  methods: {}",
+        if status.methods.is_empty() {
+            "(none)".into()
+        } else {
+            status.methods.join(", ")
+        }
+    );
+    println!("  p2p: {}", status.p2p.status);
+    println!("  safety: profile node only; no funds moved, no Bitcoin tx signing, no broadcast");
+    Ok(())
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(request: &mut Request) -> Result<T> {
+    let mut body = String::new();
+    request.as_reader().read_to_string(&mut body)?;
+    if body.trim().is_empty() {
+        anyhow::bail!("request body must be JSON");
+    }
+    Ok(serde_json::from_str(&body)?)
+}
+
+fn json_result<T: Serialize>(
+    status: StatusCode,
+    result: Result<T>,
+) -> Response<std::io::Cursor<Vec<u8>>> {
+    match result {
+        Ok(value) => json_response(status, &value),
+        Err(e) => json_error(StatusCode(500), e),
+    }
+}
+
+fn json_response<T: Serialize>(
+    status: StatusCode,
+    value: &T,
+) -> Response<std::io::Cursor<Vec<u8>>> {
+    let body =
+        serde_json::to_vec_pretty(value).unwrap_or_else(|_| b"{\"error\":\"json\"}".to_vec());
+    Response::from_data(body)
+        .with_status_code(status)
+        .with_header(json_header())
+}
+
+fn json_error(status: StatusCode, error: anyhow::Error) -> Response<std::io::Cursor<Vec<u8>>> {
+    json_response(
+        status,
+        &ErrorResponse {
+            error: error.to_string(),
+        },
+    )
+}
+
+fn json_header() -> Header {
+    Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).expect("valid static header")
+}
+
+fn safety_warnings() -> Vec<&'static str> {
+    vec![
+        "satspathd does not move funds",
+        "satspathd does not sign Bitcoin transactions",
+        "satspathd does not broadcast transactions",
+        "payment execution happens in an external wallet",
+    ]
+}
+
+fn wallet_path(home: &Path) -> PathBuf {
+    home.join(WALLET_FILE)
+}
+
+fn default_home() -> PathBuf {
+    if let Some(home) = std::env::var_os("HOME") {
+        PathBuf::from(home).join(".satspath")
+    } else {
+        PathBuf::from(".satspath")
+    }
+}
+
+fn now() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+fn bitcoin_network(network: &str) -> BitcoinNetwork {
+    match network.to_ascii_lowercase().as_str() {
+        "mainnet" | "bitcoin" => BitcoinNetwork::Mainnet,
+        "regtest" => BitcoinNetwork::Regtest,
+        // devnet uses testnet-form receive addresses until a distinct core
+        // network enum is added.
+        _ => BitcoinNetwork::Testnet,
+    }
+}
+
+fn env_truthy(name: &str) -> bool {
+    std::env::var(name)
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+fn sanitize(alias: &str) -> String {
+    alias
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_creation_persists_public_wallet_state_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let wallet = load_or_create_identity(dir.path()).unwrap();
+        assert!(wallet.identity_pubkey.is_some());
+        let raw = fs::read_to_string(wallet_path(dir.path())).unwrap();
+        assert!(!raw.contains("xprv"));
+        assert!(!raw.contains("mnemonic"));
+        assert!(!raw.contains("secret_key"));
+    }
+
+    #[test]
+    fn profile_signing_writes_resolvable_signed_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut wallet = load_or_create_identity(dir.path()).unwrap();
+        wallet.alias = Some("alice@example.com".into());
+        wallet.lightning_address = Some("alice@example.com".into());
+        sign_and_store(dir.path(), &mut wallet, "devnet").unwrap();
+
+        let signed = Registry::open(dir.path())
+            .unwrap()
+            .resolve_alias("alice@example.com")
+            .unwrap()
+            .clone();
+        assert!(verify_signed_profile(&signed).unwrap());
+        assert_eq!(signed.profile.methods.len(), 1);
+    }
+}

--- a/crates/satspathd/src/main.rs
+++ b/crates/satspathd/src/main.rs
@@ -330,7 +330,14 @@ async fn main() -> Result<()> {
 }
 
 async fn serve(state: AppState) -> Result<()> {
-    let server = Server::http(state.bind).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let server = Server::http(state.bind).map_err(|e| {
+        anyhow::anyhow!(
+            "could not bind {}: {e}\n\nThe address may already be in use by another \
+             satspathd instance. Stop it, or choose another port with \
+             `--bind 127.0.0.1:<port>`.",
+            state.bind
+        )
+    })?;
     let url = format!("http://{}/", state.bind);
     println!("Wallet UI → {url}");
     if state.open_ui {


### PR DESCRIPTION
## Safe SatsPath wallet profile manager

Adds a `satspath wallet` namespace — a **receiver-profile wallet, not a spending wallet**.

- **Adds a receiver-profile wallet** — `init`, `add-methods`, `add-lightning`, `add-onchain`, `add-ark`, `show`, `publish`, `receive`.
- **Stores public receive pointers** — `.satspath/wallet.json` holds public data only (alias, identity *public* key, Lightning Address, on-chain address, Ark server/pubkey, timestamps). The identity **signing** key stays in the existing gitignored, owner-only keystore; every save runs `assert_no_private_material`.
- **Signs SatsPath profiles** — builds a `PaymentProfile` from the public methods and signs it with the identity key (secp256k1), storing it in the local registry.
- **Integrates quote/preview** — `wallet receive <alias> <sats> --json` reuses the router quote pipeline and emits preview-only JSON:
  ```json
  { "status": "ok", "mode": "preview_only", "alias": "...", "fingerprint": "...",
    "selected_rail": "Lightning | Onchain | Ark", "qr": "...",
    "warnings": ["No funds moved by SatsPath", "Payment execution happens in external wallet"] }
  ```
- **Does not move funds** — never signs Bitcoin transactions, broadcasts, or spends Ark VTXOs.
- **Does not store spending keys** — never asks for or stores seeds, xprv/tprv, descriptors with private data, macaroons, certs, API keys, passwords, or spending keys.

### Acceptance flow (verified end-to-end)
```bash
satspath wallet init
satspath wallet add-methods rodrigodiazgt7@gmail.com \
  --lightning-address rodrigodiazgt7@gmail.com \
  --onchain-address bc1q... --ark-server https://ark... --ark-pubkey 02...
satspath wallet show
satspath wallet receive rodrigodiazgt7@gmail.com 100000 --json
```

Also: an invalid local signature now suggests re-running `wallet add-methods` (tampered or stale-schema), not just "tampered".

### Tests & gates
3 unit + 2 end-to-end binary tests (full flow incl. no-private-material assertions; tampering a saved method breaks signature verification). Full suite **207 passing**. `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update — also adds a minimal private "Receive" web UI (`satspath web`)

Built on the wallet above (it reuses `wallet::local_receive_qr`), so it ships in this PR rather than a separate one that could not compile without the wallet code.

- **Elegant black & white, one button.** Defined serif + mono font stacks, **no external fonts/CDNs** (nothing leaks to third parties).
- **Private by construction:** binds to `127.0.0.1` only; **no mempool/LNURL/DNS calls**; shows only a **masked** alias (`r***@gmail.com`) — never the raw identifier or identity pubkey. The peer registry stays hashed.
- Computes the receive route locally (Lightning → on-chain → Ark) and renders the QR as a self-contained **B&W SVG** generated from the QR matrix.
- **No funds moved, nothing signed or broadcast** — receive pointer only.

```bash
satspath wallet init && satspath wallet add-methods you@dom --lightning-address you@dom --onchain-address bc1q...
satspath web            # → http://127.0.0.1:4848   (one "Recibir" button → QR)
```

Adds 3 web unit tests (SVG QR is B&W, JSON escaping, error JSON). Full suite **210 passing**; fmt + clippy `--all-targets -D warnings` clean.