### PR TITLE
[codex] Wire daemon into P2P profile resolution

### DIFF
--- a/crates/satspathd/Cargo.toml
+++ b/crates/satspathd/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = "0.1"
 chrono = { workspace = true }
 clap = { workspace = true }
 hex = { workspace = true }

--- a/crates/satspathd/src/main.rs
+++ b/crates/satspathd/src/main.rs
@@ -9,15 +9,18 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use clap::Parser;
 use qrcode::{Color, QrCode};
 use satspath_core::ark::validate_ark_server_url;
 use satspath_core::bip321::{parse_bip321, ParsedBip321Uri};
 use satspath_core::bip353::{resolve_bip353_with, Bip353Resolution, DnssecPolicy, DohTxtResolver};
 use satspath_core::crypto::{
-    fingerprint_pubkey, generate_identity_keypair, sign_profile, verify_signed_profile,
+    check_profile_expiry, fingerprint_pubkey, generate_identity_keypair, sign_profile,
+    verify_signed_profile,
 };
 use satspath_core::peer_registry::{LocalPeerRegistry, PeerRecord, PeerRegistryBackend};
 use satspath_core::privacy::mask_identifier;
@@ -29,15 +32,20 @@ use satspath_core::validation::{
     assert_no_private_material, validate_amount_sats, validate_bitcoin_address,
     validate_compressed_pubkey, validate_lightning_address,
 };
-use satspath_core::{BitcoinNetwork, PaymentMethod, PaymentProfile, SignedPaymentProfile};
+use satspath_core::{
+    BitcoinNetwork, PaymentMethod, PaymentProfile, SatsPathError, SignedPaymentProfile,
+};
 use satspath_router::fees::fetch_fee_estimate;
 use satspath_router::select_priority_route;
 use satspath_router::QuoteResponse;
 use serde::{Deserialize, Serialize};
 use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
+use tokio::process::Command as TokioCommand;
+use tokio::time::timeout;
 
 const DEFAULT_BIND: &str = "127.0.0.1:9737";
 const DEFAULT_NETWORK: &str = "devnet";
+const P2P_RESOLVE_TIMEOUT: Duration = Duration::from_secs(10);
 const WALLET_FILE: &str = "wallet.json";
 const IDENTITY_SUBDIR: &str = "identity";
 
@@ -470,7 +478,10 @@ fn update_profile(state: &AppState, body: ProfileUpdateRequest) -> Result<Profil
 
 fn create_challenge(_state: &AppState, body: AliasRequest) -> Result<serde_json::Value> {
     use satspath_core::platform::{EmailVerifier, MockEmailVerifier};
-    let verifier = MockEmailVerifier { now: chrono::Utc::now().timestamp(), ttl_seconds: 600 };
+    let verifier = MockEmailVerifier {
+        now: chrono::Utc::now().timestamp(),
+        ttl_seconds: 600,
+    };
     let challenge = verifier.create_challenge(&body.alias)?;
     Ok(serde_json::json!({
         "challenge_id": challenge.challenge_id,
@@ -480,9 +491,12 @@ fn create_challenge(_state: &AppState, body: AliasRequest) -> Result<serde_json:
 
 fn verify_challenge(state: &AppState, body: VerifyRequest) -> Result<ProfileResponse> {
     use satspath_core::platform::{EmailVerifier, MockEmailVerifier};
-    let verifier = MockEmailVerifier { now: chrono::Utc::now().timestamp(), ttl_seconds: 600 };
+    let verifier = MockEmailVerifier {
+        now: chrono::Utc::now().timestamp(),
+        ttl_seconds: 600,
+    };
     let verified = verifier.verify_challenge(&body.token)?;
-    
+
     if verified.identifier_hash != satspath_core::privacy::identifier_hash(&body.alias) {
         anyhow::bail!("invalid verification token for this alias");
     }
@@ -490,9 +504,12 @@ fn verify_challenge(state: &AppState, body: VerifyRequest) -> Result<ProfileResp
     let mut wallet = load_or_create_identity(&state.home)?;
     wallet.alias = Some(body.alias);
     wallet.updated_at = Some(chrono::Utc::now().timestamp());
-    
+
     // Only sign and store if there are methods already. Otherwise just save the wallet state.
-    if wallet.lightning_address.is_some() || wallet.onchain_address.is_some() || wallet.ark_server.is_some() {
+    if wallet.lightning_address.is_some()
+        || wallet.onchain_address.is_some()
+        || wallet.ark_server.is_some()
+    {
         sign_and_store(&state.home, &mut wallet, &state.network)?;
     }
     save_wallet(&state.home, &wallet)?;
@@ -882,6 +899,86 @@ fn resolver_chain(home: &Path) -> ChainResolver {
         .push(Bip353Resolver::new())
         .push(HttpResolver::new())
         .push(NostrResolver::new())
+        .push(P2pSdkResolver::new(home.to_path_buf()))
+}
+
+struct P2pSdkResolver {
+    home: PathBuf,
+    sdk_dir: PathBuf,
+}
+
+impl P2pSdkResolver {
+    fn new(home: PathBuf) -> Self {
+        let sdk_dir = std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join("sdk")
+            .join("satspath-p2p");
+        Self { home, sdk_dir }
+    }
+
+    fn script(&self) -> PathBuf {
+        self.sdk_dir.join("examples").join("resolve.mjs")
+    }
+}
+
+#[async_trait]
+impl satspath_core::resolver::ProfileResolver for P2pSdkResolver {
+    async fn resolve_alias(&self, alias: &str) -> satspath_core::Result<SignedPaymentProfile> {
+        let script = self.script();
+        if !script.exists() {
+            return Err(SatsPathError::AliasNotFound(format!(
+                "P2P resolver unavailable: {}",
+                script.display()
+            )));
+        }
+
+        let output = timeout(
+            P2P_RESOLVE_TIMEOUT,
+            TokioCommand::new("node")
+                .arg("examples/resolve.mjs")
+                .arg(alias)
+                .arg("--json")
+                .arg("--timeout-ms")
+                .arg("8000")
+                .current_dir(&self.sdk_dir)
+                .output(),
+        )
+        .await
+        .map_err(|_| SatsPathError::NetworkError("P2P resolve timed out".into()))?
+        .map_err(|e| SatsPathError::NetworkError(format!("starting P2P resolver: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(SatsPathError::AliasNotFound(if stderr.is_empty() {
+                alias.to_string()
+            } else {
+                format!("P2P not found: {stderr}")
+            }));
+        }
+
+        let signed: SignedPaymentProfile = serde_json::from_slice(&output.stdout)
+            .map_err(|e| SatsPathError::SerializationError(format!("P2P profile JSON: {e}")))?;
+        if signed.profile.alias.trim().eq_ignore_ascii_case(alias)
+            && verify_signed_profile(&signed)?
+        {
+            check_profile_expiry(&signed.profile)?;
+            cache_p2p_profile(&self.home, alias, &signed)?;
+            Ok(signed)
+        } else {
+            Err(SatsPathError::InvalidSignature)
+        }
+    }
+}
+
+fn cache_p2p_profile(
+    home: &Path,
+    alias: &str,
+    signed: &SignedPaymentProfile,
+) -> satspath_core::Result<()> {
+    Registry::open(home)?.update_profile(signed.clone())?;
+    let record = PeerRecord::from_signed_profile(alias, signed);
+    LocalPeerRegistry::open(home)?.put(alias, record)?;
+    Ok(())
 }
 
 fn build_methods(wallet: &WalletState, network: &str) -> Vec<PaymentMethod> {
@@ -1402,8 +1499,12 @@ async fn send_response(state: &AppState, body: SendRequest) -> SendResponse {
             }
             let fee = fetch_fee_estimate().await;
             let routing_ok = body.routing_ok.unwrap_or(true);
-            match select_priority_route(body.amount_sats, &fee.unwrap_or_default(), &signed.profile.methods, routing_ok)
-            {
+            match select_priority_route(
+                body.amount_sats,
+                &fee.unwrap_or_default(),
+                &signed.profile.methods,
+                routing_ok,
+            ) {
                 Some(decision) => {
                     let payload = match send_payload_for(&decision.method, body.amount_sats) {
                         Ok(p) => p,
@@ -1442,7 +1543,8 @@ async fn send_response(state: &AppState, body: SendRequest) -> SendResponse {
             }
         }
         Err(_) => {
-            let invite = satspath_core::create_invite(&body.recipient, body.amount_sats, None, 86400);
+            let invite =
+                satspath_core::create_invite(&body.recipient, body.amount_sats, None, 86400);
             let email = build_email_invite(&body.recipient, body.amount_sats, &invite.claim_url);
             SendResponse::Invite {
                 mode: "preview_only",
@@ -1511,6 +1613,10 @@ fn broadcast(state: &AppState) -> Result<serde_json::Value> {
         anyhow::bail!("set your profile first (alias + methods) before broadcasting");
     }
     let mut bridge = state.p2p.lock().unwrap();
+    if let Some(mut child) = bridge.child.take() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
     match start_p2p_bridge(&state.home, &wallet) {
         Ok((status, child)) => {
             bridge.enabled = true;

--- a/sdk/satspath-p2p/examples/resolve.mjs
+++ b/sdk/satspath-p2p/examples/resolve.mjs
@@ -7,22 +7,31 @@
 
 import { SatsPathP2PNode } from "../src/index.js";
 
-const alias = process.argv[2];
+const args = process.argv.slice(2);
+const json = args.includes("--json");
+const timeoutIdx = args.indexOf("--timeout-ms");
+const timeoutMs =
+  timeoutIdx >= 0 && args[timeoutIdx + 1]
+    ? Number.parseInt(args[timeoutIdx + 1], 10)
+    : 20000;
+const alias = args.find((arg) => !arg.startsWith("--") && arg !== String(timeoutMs));
 if (!alias) {
-  console.error("usage: node examples/resolve.mjs <alias>");
+  console.error("usage: node examples/resolve.mjs <alias> [--json] [--timeout-ms <ms>]");
   process.exit(1);
 }
 
 const node = new SatsPathP2PNode();
-console.log("SatsPath P2P node address:", node.address);
-console.log(`Resolving ${alias} over Holepunch...`);
+if (!json) {
+  console.log("SatsPath P2P node address:", node.address);
+  console.log(`Resolving ${alias} over Holepunch...`);
+}
 
 try {
-  const signed = await node.resolve(alias, { timeoutMs: 20000 });
-  console.log("✓ Resolved and signature-verified:");
+  const signed = await node.resolve(alias, { timeoutMs });
+  if (!json) console.log("✓ Resolved and signature-verified:");
   console.log(JSON.stringify(signed, null, 2));
 } catch (e) {
-  console.error("✗", e.message);
+  console.error(json ? e.message : `✗ ${e.message}`);
   process.exitCode = 1;
 } finally {
   await node.destroy();

--- a/sdk/satspath-p2p/src/topic.js
+++ b/sdk/satspath-p2p/src/topic.js
@@ -13,8 +13,8 @@ const TOPIC_PREFIX = "satspath:p2p:v1:";
 /**
  * The 32-byte Hyperswarm/HyperDHT topic for a SatsPath alias.
  * @param {string} alias e.g. "rodrigo@satspath.dev"
- * @returns {Uint8Array} 32 bytes
+ * @returns {Buffer} 32 bytes
  */
 export function topicForAlias(alias) {
-  return sha256(new TextEncoder().encode(TOPIC_PREFIX + canonicalAlias(alias)));
+  return Buffer.from(sha256(new TextEncoder().encode(TOPIC_PREFIX + canonicalAlias(alias))));
 }


### PR DESCRIPTION
## Summary

Fixes the P2P publish/resolve gap in the wallet daemon.

- Adds a daemon-side P2P resolver that calls the JS Holepunch SDK after local/BIP-353/HTTPS/Nostr resolvers.
- Verifies resolved signed profiles in Rust before returning them.
- Caches P2P-resolved profiles into the local registry and peer registry.
- Makes repeated `Publish (P2P)` calls replace the previous publisher instead of leaking old Node processes.
- Makes the SDK resolver support clean JSON output and uses a Buffer topic as required by Hyperswarm.

## Validation

- `cargo fmt -p satspathd --check`
- `cargo check -p satspathd`
- `npm test` in `sdk/satspath-p2p`

## Note

A live DHT resolve can still timeout when the network/NAT/firewall blocks Holepunch discovery, but the daemon now actually participates in P2P resolution instead of only publishing.