### PR TITLE
[codex] Repair P2P publish profile handling

### DIFF
--- a/crates/satspathd/src/main.rs
+++ b/crates/satspathd/src/main.rs
@@ -1099,6 +1099,7 @@ fn start_p2p_bridge(home: &Path, wallet: &WalletState) -> Result<(String, Child)
     }
     let out_path = home.join(format!("{}-profile.json", sanitize(alias)));
     fs::write(&out_path, serde_json::to_string_pretty(&signed)?)?;
+    let out_path = std::fs::canonicalize(&out_path)?;
 
     let repo_root = std::env::current_dir()?;
     let sdk_dir = repo_root.join("sdk").join("satspath-p2p");
@@ -1608,10 +1609,11 @@ fn send_payload_for(method: &PaymentMethod, amount_sats: u64) -> Result<String> 
 /// Publish the local signed profile over the Holepunch P2P bridge so peers can
 /// resolve it. Returns the bridge status. (Best-effort; needs the JS SDK.)
 fn broadcast(state: &AppState) -> Result<serde_json::Value> {
-    let wallet = load_wallet(&state.home)?;
+    let mut wallet = load_wallet(&state.home)?;
     if wallet.alias.is_none() {
         anyhow::bail!("set your profile first (alias + methods) before broadcasting");
     }
+    ensure_signed_profile(&state.home, &mut wallet, &state.network)?;
     let mut bridge = state.p2p.lock().unwrap();
     if let Some(mut child) = bridge.child.take() {
         let _ = child.kill();
@@ -1629,6 +1631,19 @@ fn broadcast(state: &AppState) -> Result<serde_json::Value> {
             Ok(serde_json::json!({ "broadcasting": false, "status": bridge.status }))
         }
     }
+}
+
+fn ensure_signed_profile(home: &Path, wallet: &mut WalletState, network: &str) -> Result<()> {
+    if let Some(alias) = wallet.alias.as_deref() {
+        if let Ok(signed) = Registry::open(home)?.resolve_alias(alias) {
+            if verify_signed_profile(signed)? {
+                return Ok(());
+            }
+        }
+    }
+    sign_and_store(home, wallet, network)?;
+    save_wallet(home, wallet)?;
+    Ok(())
 }
 
 fn fmt_btc(sats: u64) -> String {

--- a/sdk/satspath-p2p/src/profile.js
+++ b/sdk/satspath-p2p/src/profile.js
@@ -1,10 +1,9 @@
 // SatsPath signed-profile verification, native in JS.
 //
-// SatsPath signs `SHA-256(serde_json::to_string(profile))` with secp256k1 ECDSA
-// (DER signature, compressed pubkey). JavaScript preserves object key insertion
-// order, so `JSON.stringify(profile)` of a profile parsed from `satspath export`
-// reproduces Rust's exact canonical bytes — verified against a real Rust
-// signature in the test suite. No re-implementation of serde is required.
+// Current Rust signs `SHA-256(canonical_json(profile))` with secp256k1 ECDSA
+// (DER signature, compressed pubkey), where canonical JSON sorts object keys.
+// Older fixtures used Rust's serde insertion order, so verification accepts both
+// current canonical JSON and the legacy compact JSON encoding.
 
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { sha256 } from "@noble/hashes/sha256";
@@ -14,9 +13,9 @@ export function canonicalAlias(alias) {
   return String(alias).trim().toLowerCase();
 }
 
-/** The exact bytes SatsPath signed: UTF-8 of compact JSON, in field order. */
+/** Current canonical JSON bytes: UTF-8 of JSON with object keys sorted. */
 export function canonicalProfileBytes(profile) {
-  return new TextEncoder().encode(JSON.stringify(profile));
+  return new TextEncoder().encode(canonicalJson(profile));
 }
 
 /**
@@ -29,10 +28,23 @@ export function verifySignedProfile(signed) {
     const pubkey = signed?.profile?.identity_pubkey;
     const signature = signed?.signature;
     if (typeof pubkey !== "string" || typeof signature !== "string") return false;
-    const msgHash = sha256(canonicalProfileBytes(signed.profile));
     const sig = secp256k1.Signature.fromDER(signature);
-    return secp256k1.verify(sig, msgHash, pubkey);
+    const currentHash = sha256(canonicalProfileBytes(signed.profile));
+    if (secp256k1.verify(sig, currentHash, pubkey)) return true;
+
+    const legacyHash = sha256(new TextEncoder().encode(JSON.stringify(signed.profile)));
+    return secp256k1.verify(sig, legacyHash, pubkey);
   } catch {
     return false;
   }
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+    .join(",")}}`;
 }


### PR DESCRIPTION
## Summary

Repairs the remaining P2P publish failures found after merging the daemon resolver.

- Makes `broadcast` ensure a valid signed profile exists before starting the P2P publisher.
- Avoids re-signing when a valid profile already exists, so sequence-number replay protection does not reject publish.
- Passes the signed profile JSON to the Node publisher as an absolute path, since the child runs with `sdk/satspath-p2p` as its working directory.
- Updates JS profile verification to support current Rust `canonical_json` signatures while retaining legacy fixture compatibility.

## Validation

- `cargo fmt -p satspathd --check`
- `cargo check -p satspathd`
- `npm test` in `sdk/satspath-p2p`
- Local `/v1/broadcast` now returns `broadcasting: true` and `/v1/node` reports active P2P bridge.