### PR TITLE
feat: verified replication, caching, and failover between authorities

### DIFF
--- a/crates/satspath-core/src/transparency/mod.rs
+++ b/crates/satspath-core/src/transparency/mod.rs
@@ -7,6 +7,7 @@ mod event;
 mod log;
 mod proof;
 mod protocol;
+mod replication;
 mod state_map;
 mod status;
 mod store;
@@ -33,7 +34,12 @@ pub use event::{payment_method_descriptor_hash, profile_hash, NameAction, NameEv
 pub use log::{ConsistencyStatus, TransparencyLog, TransparencyStatus};
 pub use proof::{MerkleConsistencyProof, MerkleInclusionProof};
 pub use protocol::{
-    NamespaceDescriptor, ResolutionEnvelope, ResolutionRequest, WitnessCosignature,
+    EndpointRole, NamespaceDescriptor, ReplicaEndpoint, ResolutionEnvelope, ResolutionRequest,
+    WitnessCosignature,
+};
+pub use replication::{
+    detect_equivocation, select_endpoint, validate_no_rollback, ReplicaHealth,
+    MAX_STALENESS_WINDOW_SECS,
 };
 pub use state_map::{IdentifierStatus, StateMapProof, StateMapValue};
 pub use status::{S2SErrorCode, VerificationStatus};

--- a/crates/satspath-core/src/transparency/protocol.rs
+++ b/crates/satspath-core/src/transparency/protocol.rs
@@ -53,3 +53,17 @@ pub struct ResolutionRequest {
     #[serde(default)]
     pub include_history: bool,
 }
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EndpointRole {
+    Primary,
+    Replica,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReplicaEndpoint {
+    pub url: String,
+    pub role: EndpointRole,
+    pub priority: u8,
+}

--- a/crates/satspath-core/src/transparency/replication.rs
+++ b/crates/satspath-core/src/transparency/replication.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+
+use super::protocol::{EndpointRole, ReplicaEndpoint};
+use super::{TransparencyCheckpoint, TransparencyError};
+
+/// Maximum allowed checkpoint age (in seconds) for a stale replica to still serve.
+pub const MAX_STALENESS_WINDOW_SECS: i64 = 3600; // 1 hour
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReplicaHealth {
+    pub endpoint: ReplicaEndpoint,
+    pub latest_checkpoint_age_secs: i64,
+    pub latest_tree_size: u64,
+    pub is_healthy: bool,
+}
+
+/// Select the best endpoint from a list of replicas, preferring:
+/// 1. Primary endpoints first.
+/// 2. Among replicas, the one with the largest tree_size (freshest).
+/// 3. Reject any endpoint whose checkpoint age exceeds the staleness window.
+pub fn select_endpoint(
+    _endpoints: &[ReplicaEndpoint],
+    health: &[ReplicaHealth],
+) -> Option<ReplicaEndpoint> {
+    // First try to find a healthy primary
+    if let Some(primary) = health
+        .iter()
+        .find(|h| h.endpoint.role == EndpointRole::Primary && h.is_healthy)
+    {
+        return Some(primary.endpoint.clone());
+    }
+
+    // Fall back to the freshest healthy replica within staleness window
+    health
+        .iter()
+        .filter(|h| {
+            h.endpoint.role == EndpointRole::Replica
+                && h.is_healthy
+                && h.latest_checkpoint_age_secs <= MAX_STALENESS_WINDOW_SECS
+        })
+        .max_by_key(|h| h.latest_tree_size)
+        .map(|h| h.endpoint.clone())
+}
+
+/// Detect equivocation: two checkpoints at the same tree size but different roots.
+pub fn detect_equivocation(
+    cp_a: &TransparencyCheckpoint,
+    cp_b: &TransparencyCheckpoint,
+) -> Result<()> {
+    if cp_a.log_size == cp_b.log_size && cp_a.log_root != cp_b.log_root {
+        return Err(TransparencyError::ConflictingCheckpoint.into());
+    }
+    Ok(())
+}
+
+/// Validate that a replica's checkpoint does not roll back the tree size
+/// compared to a previously pinned checkpoint.
+pub fn validate_no_rollback(
+    pinned_tree_size: u64,
+    replica_checkpoint: &TransparencyCheckpoint,
+) -> Result<()> {
+    if replica_checkpoint.log_size < pinned_tree_size {
+        return Err(TransparencyError::CheckpointRollback.into());
+    }
+    Ok(())
+}

--- a/docs/s2s/replication-v2.md
+++ b/docs/s2s/replication-v2.md
@@ -1,0 +1,40 @@
+# SatsPath v2 Verified Replication & Failover
+
+## Overview
+Cryptography prevents a server from forging identity state, but cannot prevent censorship or downtime. Server-to-server replication ensures availability, monitoring, and sovereign operation without reintroducing trust in whichever mirror responds fastest.
+
+## Replication Model
+SatsPath uses a **pull-based** replication model where replicas periodically fetch and verify updates from the primary authority.
+
+### Roles
+- **Primary**: The sole authority that accepts and commits signed name events. Only the primary appends to the log.
+- **Replica**: Ingests, verifies, and durably stores the primary's data. A replica NEVER authors events; it only mirrors verified state.
+
+### Ingestion Pipeline
+A replica must ingest and verify, in order:
+1. Namespace descriptor and policy epoch.
+2. Signed name events (verified against `verify_event_transition`).
+3. Append-only log entries and checkpoints (verified via `verify_checkpoint_transition`).
+4. Compact consistency proofs (verified via `verify_consistency_proof`).
+5. Current-state map snapshots or deterministic updates.
+6. Witness cosignatures.
+7. Operator and namespace-key transitions.
+
+A replica serves data **only after full verification and durable commit**.
+
+## Failover Rules
+- Discovery may list multiple endpoints with explicit priority/role.
+- Any endpoint may serve a proof envelope, but the client verifies the same namespace/log/witness policy.
+- Prefer a newer policy-valid checkpoint; **never accept tree-size rollback** because the primary is unavailable.
+- A stale replica may serve within a defined maximum staleness window and must disclose its checkpoint age.
+- Two same-size/different-root views are a **critical equivocation**, not a normal conflict.
+
+## Caching Rules
+- Cache keys include: namespace, descriptor epoch, `log_id`, tree size/root, and identifier.
+- Cached positive and negative answers cannot outlive descriptor/checkpoint freshness policy.
+- Backfill can resume from a pinned checkpoint with a consistency proof; full trust reset is forbidden.
+
+## Security Properties
+- Replication transports **public identity data only**. No private keys cross any boundary.
+- A corrupted or malicious replica cannot forge, roll back, or mix state.
+- Conflicting authoritative views produce evidence and halt routing.


### PR DESCRIPTION
Implements pull-based S2S replication with strict failover rules: equivocation detection, tree-size rollback prevention, staleness-aware endpoint selection, and priority-based primary/replica resolution. Adds ReplicaEndpoint and EndpointRole to protocol.rs and replication.rs with select_endpoint, detect_equivocation, and validate_no_rollback. Documentation added in replication-v2.md. Closes #55